### PR TITLE
fix: register missing GitCharm command palette actions

### DIFF
--- a/src/host/commands/registerCommands.ts
+++ b/src/host/commands/registerCommands.ts
@@ -29,6 +29,18 @@ export function registerCommands(
       mergeEditor.openCurrentEditorFile();
     }),
 
+    vscode.commands.registerCommand('gitcharm.commit', () => {
+      vscode.commands.executeCommand('gitcharm.commitPanel.focus');
+    }),
+
+    vscode.commands.registerCommand('gitcharm.pull', () => {
+      return branchStatusBar.updateProject();
+    }),
+
+    vscode.commands.registerCommand('gitcharm.push', () => {
+      return branchStatusBar.push();
+    }),
+
     vscode.commands.registerCommand('gitcharm.fetchAll', async () => {
       await vscode.window.withProgress(
         { location: vscode.ProgressLocation.Notification, title: 'GitCharm: Fetching all remotes', cancellable: false },

--- a/src/host/ui/BranchStatusBar.ts
+++ b/src/host/ui/BranchStatusBar.ts
@@ -615,6 +615,10 @@ export class BranchStatusBar implements vscode.Disposable {
     if (pick) await pick.action();
   }
 
+  async push(): Promise<void> {
+    await this.pushMenu(this.manager.getRepoMetas());
+  }
+
   private async pushMenu(metas: RepoMeta[]): Promise<void> {
     type RepoRemoteItem = vscode.QuickPickItem & { repoId: string; remote: string };
 


### PR DESCRIPTION
Register missing commands that are contributed in `package.json` but were not registered at activation time.
Without this, invoking these commands from the Command Palette fails with errors such as:

- `command 'gitcharm.commit' not found`
- `command 'gitcharm.pull' not found`
- `command 'gitcharm.push' not found`