### PR TITLE
fix: make Fetch All Remotes command actually fetch repositories

### DIFF
--- a/src/host/commands/registerCommands.ts
+++ b/src/host/commands/registerCommands.ts
@@ -29,11 +29,8 @@ export function registerCommands(
       mergeEditor.openCurrentEditorFile();
     }),
 
-    vscode.commands.registerCommand('gitcharm.fetchAll', async () => {
-      await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: 'GitCharm: Fetching all remotes', cancellable: false },
-        async () => { /* delegated to panel message handler */ }
-      );
+    vscode.commands.registerCommand('gitcharm.fetchAll', () => {
+      return branchStatusBar.fetchAll();
     }),
 
     vscode.commands.registerCommand('gitcharm.showBranchMenu', (repoId?: string) => {

--- a/src/host/ui/BranchStatusBar.ts
+++ b/src/host/ui/BranchStatusBar.ts
@@ -681,6 +681,21 @@ export class BranchStatusBar implements vscode.Disposable {
     await this.refresh();
   }
 
+  async fetchAll(): Promise<void> {
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'GitCharm: Fetching all remotes…',
+        cancellable: false,
+      },
+      async () => {
+        await this.manager.fetchAll();
+      }
+    );
+    await this.refresh();
+    vscode.window.showInformationMessage('GitCharm: Fetch complete.');
+  }
+
   async updateProject(): Promise<void> {
     const pick = await vscode.window.showQuickPick(
       [


### PR DESCRIPTION
The `GitCharm: Fetch All Remotes` command was registered, but its command handler only displayed a progress notification and did not actually trigger any fetch operation. As a result, running the command from VS Code did not update remotes or refresh branch status.

- Updated the `gitcharm.fetchAll` command to delegate to `BranchStatusBar.fetchAll()`.
- Added `BranchStatusBar.fetchAll()` to:
  - show fetch progress
  - call `WorkspaceGitManager.fetchAll()`
  - refresh the branch/status UI after fetching
  - show a completion message

(AI-assisted-by: ChatGPT)