### PR TITLE
Add file-level cherry-pick from commit detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ On first install, a QuickPick lets you choose your preferred view mode. You can 
 - Commit detail with changed-file list and per-file diffs.
 - Smart diff resolution for added, deleted, renamed, copied, merge, and root commits.
 - **Show Combined Diff** context menu entry in the commit file list.
+- **Cherry-Pick Selected Changes** from a file in a commit directly into the current working tree.
 - Close button in the commit detail panel; clicking any commit re-opens it.
 - Bold commit message for the HEAD commit in the list.
 - Author name shown in commit rows when panel width > 500 px.

--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -1,5 +1,6 @@
 import simpleGit, { SimpleGit } from 'simple-git';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import type {
   BranchInfo,
@@ -1301,6 +1302,37 @@ export class GitService {
 
   async cherryPick(hash: string): Promise<void> {
     await this.git.raw(['cherry-pick', hash]);
+  }
+
+  async cherryPickFile(hash: string, filePath: string, oldPath?: string): Promise<void> {
+    const parentsRaw = await this.git.raw(['log', '-1', '--format=%P', hash]).catch(() => '');
+    const parents = parentsRaw.trim().split(' ').filter(Boolean);
+    const base = parents[0] ?? '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+    const paths = [...new Set([oldPath, filePath].filter((p): p is string => Boolean(p)))];
+    const patch = await this.git.raw(['diff', '--binary', '--find-renames', base, hash, '--', ...paths]);
+    if (!patch.trim()) {
+      throw new Error(`No changes found for ${filePath} in ${hash.slice(0, 8)}`);
+    }
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitcharm-cherry-pick-file-'));
+    const patchPath = path.join(tmpDir, 'changes.patch');
+    fs.writeFileSync(patchPath, patch, 'utf8');
+
+    try {
+      try {
+        await this.git.raw(['apply', '--binary', '--3way', '--whitespace=fix', patchPath]);
+      } catch (e) {
+        const conflicts = await this.git.raw(['diff', '--name-only', '--diff-filter=U']).catch(() => '');
+        if (conflicts.trim()) {
+          throw new Error(`FILE_CHERRY_PICK_CONFLICT:${conflicts.trim()}`);
+        }
+        await this.git.raw(['apply', '--binary', '--whitespace=fix', patchPath]).catch(() => {
+          throw new Error(`Failed to cherry-pick selected changes: ${e}`);
+        });
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   }
 
   async cherryPickContinue(): Promise<void> {

--- a/src/host/panels/GitLogPanelProvider.ts
+++ b/src/host/panels/GitLogPanelProvider.ts
@@ -497,6 +497,28 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
         break;
       }
 
+      case 'LOG_CHERRY_PICK_FILE': {
+        const repo = this.manager.getRepo(msg.repoId);
+        if (!repo) { this.post({ type: 'LOG_FILE_OP_RESULT', requestId: msg.requestId, ok: false, error: 'Repo not found' }); return; }
+        try {
+          await repo.cherryPickFile(msg.hash, msg.filePath, msg.oldPath);
+          this.post({ type: 'LOG_FILE_OP_RESULT', requestId: msg.requestId, ok: true });
+          vscode.window.showInformationMessage(`GitCharm: Cherry-picked changes for ${msg.filePath}.`);
+        } catch (e: unknown) {
+          const errMsg = String(e);
+          this.post({ type: 'LOG_FILE_OP_RESULT', requestId: msg.requestId, ok: false, error: errMsg });
+          if (errMsg.includes('FILE_CHERRY_PICK_CONFLICT')) {
+            const files = errMsg.split('FILE_CHERRY_PICK_CONFLICT:')[1]?.trim();
+            vscode.window.showWarningMessage(
+              `GitCharm: Cherry-pick of ${msg.filePath} has conflicts${files ? ` in ${files}` : ''}. Resolve them in the editor.`
+            );
+          } else {
+            vscode.window.showErrorMessage(`GitCharm: Cannot cherry-pick file changes: ${errMsg}`);
+          }
+        }
+        break;
+      }
+
       case 'LOG_CHECKOUT': {
         const repo = this.manager.getRepo(msg.repoId);
         if (!repo) { this.post({ type: 'LOG_BRANCH_OP_RESULT', requestId: msg.requestId, ok: false, error: 'Repo not found' }); return; }

--- a/src/host/types/messages.ts
+++ b/src/host/types/messages.ts
@@ -234,6 +234,7 @@ export type LogToHostMsg =
   | { type: 'LOG_OPEN_FILE_DIFF'; repoId: string; hash: string; filePath: string; fileStatus?: string; oldPath?: string; parents?: string[]; combined?: boolean }
   | { type: 'LOG_OPEN_FILE'; repoId: string; filePath: string }
   | { type: 'LOG_REVERT_FILE'; requestId: string; repoId: string; hash: string; filePath: string; fileStatus?: string }
+  | { type: 'LOG_CHERRY_PICK_FILE'; requestId: string; repoId: string; hash: string; filePath: string; oldPath?: string }
   | { type: 'LOG_CHECKOUT'; requestId: string; repoId: string; branchName: string; createNew?: boolean; from?: string }
   | { type: 'LOG_PULL'; requestId: string; repoId: string }
   | { type: 'LOG_PUSH'; requestId: string; repoId: string; remote?: string; force?: boolean }

--- a/src/webview/gitLog/components/CommitDetail.tsx
+++ b/src/webview/gitLog/components/CommitDetail.tsx
@@ -28,13 +28,15 @@ interface FileContextMenuProps {
   onShowCombinedDiff: () => void;
   onEditSource: () => void;
   onFileHistory: () => void;
+  onCherryPickFile: () => void;
   onRevertFile: () => void;
   onRevealExplorer: () => void;
   onRevealOS: () => void;
   onClose: () => void;
+  canApplyCommitChanges: boolean;
 }
 
-function FileContextMenu({ x, y, onShowDiff, onShowCombinedDiff, onEditSource, onFileHistory, onRevertFile, onRevealExplorer, onRevealOS, onClose }: FileContextMenuProps) {
+function FileContextMenu({ x, y, onShowDiff, onShowCombinedDiff, onEditSource, onFileHistory, onCherryPickFile, onRevertFile, onRevealExplorer, onRevealOS, onClose, canApplyCommitChanges }: FileContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
 
@@ -110,7 +112,12 @@ function FileContextMenu({ x, y, onShowDiff, onShowCombinedDiff, onEditSource, o
       <Item icon="diff-multiple" label="Show Combined Diff" onClick={onShowCombinedDiff} />
       <Item icon="history" label="Show File History" onClick={onFileHistory} />
       <Item icon="go-to-file" label="Edit Source" onClick={onEditSource} />
-      <Item icon="discard" label="Revert Selected Changes" onClick={onRevertFile} />
+      {canApplyCommitChanges && (
+        <>
+          <Item icon="git-commit" label="Cherry-Pick Selected Changes" onClick={onCherryPickFile} />
+          <Item icon="discard" label="Revert Selected Changes" onClick={onRevertFile} />
+        </>
+      )}
       <Item icon="list-tree" label="Reveal in Explorer" onClick={onRevealExplorer} />
       <Item icon="folder-opened" label="Reveal in File Manager" onClick={onRevealOS} />
     </div>
@@ -451,6 +458,20 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
     } as LogToHostMsg);
     setCtxMenu(null);
   }, [ctxMenu, commit]);
+
+  const handleCtxCherryPickFile = useCallback(() => {
+    if (!ctxMenu || !commit || commit.isStash) return;
+    const reqId = generateId();
+    getVsCodeApi().postMessage({
+      type: 'LOG_CHERRY_PICK_FILE',
+      requestId: reqId,
+      repoId: commit.repoId,
+      hash: selectedMergeHash ?? commit.hash,
+      filePath: ctxMenu.file.path,
+      oldPath: ctxMenu.file.oldPath,
+    } as LogToHostMsg);
+    setCtxMenu(null);
+  }, [ctxMenu, commit, selectedMergeHash]);
 
   const handleCtxRevealExplorer = useCallback(() => {
     if (!ctxMenu || !commit) return;
@@ -835,9 +856,11 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
           onShowCombinedDiff={handleCtxShowCombinedDiff}
           onFileHistory={handleCtxFileHistory}
           onEditSource={handleCtxEditSource}
+          onCherryPickFile={handleCtxCherryPickFile}
           onRevertFile={handleCtxRevertFile}
           onRevealExplorer={handleCtxRevealExplorer}
           onRevealOS={handleCtxRevealOS}
+          canApplyCommitChanges={!commit.isStash}
           onClose={() => setCtxMenu(null)}
         />
       )}

--- a/src/webview/gitLog/components/CommitList.tsx
+++ b/src/webview/gitLog/components/CommitList.tsx
@@ -985,28 +985,71 @@ function CommitContextMenu({ commit, x, y, multiSelected, allCommits, currentBra
   return (
     <>
       <div style={ctxStyles.backdrop} onClick={onClose} />
-      <div ref={menuRef} style={ctxStyles.menu(menuPos.left, menuPos.top, menuPos.maxHeight)}>
+      <div
+        ref={menuRef}
+        style={ctxStyles.menu(menuPos.left, menuPos.top, menuPos.maxHeight)}
+      >
         <div data-ctx-item="" style={ctxStyles.item} onClick={copyHash}>
           <Codicon name="copy" style={ctxStyles.icon} />
           <span>Copy Revision Number</span>
         </div>
         <div style={ctxStyles.separator} />
-        <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_OPEN_EXTENDED_DETAIL', repoId: commit.repoId, hash: commit.hash })}>
+        <div
+          data-ctx-item=""
+          style={ctxStyles.item}
+          onClick={() =>
+            send({
+              type: "LOG_OPEN_EXTENDED_DETAIL",
+              repoId: commit.repoId,
+              hash: commit.hash,
+            })
+          }
+        >
           <Codicon name="open-preview" style={ctxStyles.icon} />
           <span>Open Full Detail</span>
         </div>
-        <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_OPEN_COMMIT_CHANGES', repoId: commit.repoId, hash: commit.hash })}>
+        <div
+          data-ctx-item=""
+          style={ctxStyles.item}
+          onClick={() =>
+            send({
+              type: "LOG_OPEN_COMMIT_CHANGES",
+              repoId: commit.repoId,
+              hash: commit.hash,
+            })
+          }
+        >
           <Codicon name="diff-multiple" style={ctxStyles.icon} />
           <span>Open Changes</span>
         </div>
         {!commit.isStash && (
-          <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_COMPARE_COMMIT_WITH', repoId: commit.repoId, hash: commit.hash })}>
+          <div
+            data-ctx-item=""
+            style={ctxStyles.item}
+            onClick={() =>
+              send({
+                type: "LOG_COMPARE_COMMIT_WITH",
+                repoId: commit.repoId,
+                hash: commit.hash,
+              })
+            }
+          >
             <Codicon name="git-compare" style={ctxStyles.icon} />
             <span>Compare with…</span>
           </div>
         )}
         {aiEnabled && (
-          <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_EXPLAIN_COMMIT', repoId: commit.repoId, hash: commit.hash })}>
+          <div
+            data-ctx-item=""
+            style={ctxStyles.item}
+            onClick={() =>
+              send({
+                type: "LOG_EXPLAIN_COMMIT",
+                repoId: commit.repoId,
+                hash: commit.hash,
+              })
+            }
+          >
             <Codicon name="sparkle" style={ctxStyles.icon} />
             <span>Explain with AI</span>
           </div>
@@ -1014,18 +1057,51 @@ function CommitContextMenu({ commit, x, y, multiSelected, allCommits, currentBra
         {commit.isStash ? (
           <>
             <div style={ctxStyles.separator} />
-            <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_STASH_POP', requestId: generateId(), repoId: commit.repoId, stashRef: commit.hash })}>
+            <div
+              data-ctx-item=""
+              style={ctxStyles.item}
+              onClick={() =>
+                send({
+                  type: "LOG_STASH_POP",
+                  requestId: generateId(),
+                  repoId: commit.repoId,
+                  stashRef: commit.hash,
+                })
+              }
+            >
               <Codicon name="git-stash-pop" style={ctxStyles.icon} />
               <span>Pop Stash</span>
             </div>
-            <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_STASH_APPLY', requestId: generateId(), repoId: commit.repoId, stashRef: commit.hash })}>
+            <div
+              data-ctx-item=""
+              style={ctxStyles.item}
+              onClick={() =>
+                send({
+                  type: "LOG_STASH_APPLY",
+                  requestId: generateId(),
+                  repoId: commit.repoId,
+                  stashRef: commit.hash,
+                })
+              }
+            >
               <Codicon name="git-stash-apply" style={ctxStyles.icon} />
               <span>Apply Stash</span>
             </div>
             <div style={ctxStyles.separator} />
             <div
-              data-ctx-item="" style={{ ...ctxStyles.item, color: 'var(--vscode-errorForeground)' }}
-              onClick={() => send({ type: 'LOG_STASH_DROP', requestId: generateId(), repoId: commit.repoId, stashRef: commit.hash })}
+              data-ctx-item=""
+              style={{
+                ...ctxStyles.item,
+                color: "var(--vscode-errorForeground)",
+              }}
+              onClick={() =>
+                send({
+                  type: "LOG_STASH_DROP",
+                  requestId: generateId(),
+                  repoId: commit.repoId,
+                  stashRef: commit.hash,
+                })
+              }
             >
               <Codicon name="trash" style={ctxStyles.icon} />
               <span>Delete Stash</span>
@@ -1034,12 +1110,34 @@ function CommitContextMenu({ commit, x, y, multiSelected, allCommits, currentBra
         ) : (
           <>
             <div style={ctxStyles.separator} />
-            <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_NEW_BRANCH_FROM_COMMIT', requestId: generateId(), repoId: commit.repoId, hash: commit.hash })}>
+            <div
+              data-ctx-item=""
+              style={ctxStyles.item}
+              onClick={() =>
+                send({
+                  type: "LOG_NEW_BRANCH_FROM_COMMIT",
+                  requestId: generateId(),
+                  repoId: commit.repoId,
+                  hash: commit.hash,
+                })
+              }
+            >
               <Codicon name="git-branch" style={ctxStyles.icon} />
               <span>New Branch...</span>
             </div>
             {tagsFromRefs.length === 0 ? (
-              <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_CREATE_TAG', requestId: generateId(), repoId: commit.repoId, hash: commit.hash })}>
+              <div
+                data-ctx-item=""
+                style={ctxStyles.item}
+                onClick={() =>
+                  send({
+                    type: "LOG_CREATE_TAG",
+                    requestId: generateId(),
+                    repoId: commit.repoId,
+                    hash: commit.hash,
+                  })
+                }
+              >
                 <Codicon name="tag" style={ctxStyles.icon} />
                 <span>New Tag...</span>
               </div>
@@ -1048,8 +1146,14 @@ function CommitContextMenu({ commit, x, y, multiSelected, allCommits, currentBra
                 data-ctx-item=""
                 style={ctxStyles.item}
                 onClick={() => {
-                  const currentBranch = currentBranchByRepo[commit.repoId] ?? '';
-                  send({ type: 'LOG_MANAGE_COMMIT_TAGS', repoId: commit.repoId, hash: commit.hash, currentBranch } satisfies LogToHostMsg);
+                  const currentBranch =
+                    currentBranchByRepo[commit.repoId] ?? "";
+                  send({
+                    type: "LOG_MANAGE_COMMIT_TAGS",
+                    repoId: commit.repoId,
+                    hash: commit.hash,
+                    currentBranch,
+                  } satisfies LogToHostMsg);
                 }}
               >
                 <Codicon name="tag" style={ctxStyles.icon} />
@@ -1058,28 +1162,83 @@ function CommitContextMenu({ commit, x, y, multiSelected, allCommits, currentBra
             )}
             <div style={ctxStyles.separator} />
             {primaryBranch ? (
-              <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_CHECKOUT_COMMIT', requestId: generateId(), repoId: commit.repoId, hash: commit.hash, branchName: primaryBranch })}>
+              <div
+                data-ctx-item=""
+                style={ctxStyles.item}
+                onClick={() =>
+                  send({
+                    type: "LOG_CHECKOUT_COMMIT",
+                    requestId: generateId(),
+                    repoId: commit.repoId,
+                    hash: commit.hash,
+                    branchName: primaryBranch,
+                  })
+                }
+              >
                 <Codicon name="arrow-right" style={ctxStyles.icon} />
                 <span>Checkout...</span>
               </div>
             ) : (
-              <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_CHECKOUT_COMMIT', requestId: generateId(), repoId: commit.repoId, hash: commit.hash })}>
+              <div
+                data-ctx-item=""
+                style={ctxStyles.item}
+                onClick={() =>
+                  send({
+                    type: "LOG_CHECKOUT_COMMIT",
+                    requestId: generateId(),
+                    repoId: commit.repoId,
+                    hash: commit.hash,
+                  })
+                }
+              >
                 <Codicon name="arrow-right" style={ctxStyles.icon} />
                 <span>Checkout Revision</span>
               </div>
             )}
             {primaryBranch && (
-              <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_SHOW_BRANCH_OPTIONS', repoId: commit.repoId, branchName: primaryBranch })}>
+              <div
+                data-ctx-item=""
+                style={ctxStyles.item}
+                onClick={() =>
+                  send({
+                    type: "LOG_SHOW_BRANCH_OPTIONS",
+                    repoId: commit.repoId,
+                    branchName: primaryBranch,
+                  })
+                }
+              >
                 <Codicon name="git-branch" style={ctxStyles.icon} />
                 <span>Branch options...</span>
               </div>
             )}
             <div style={ctxStyles.separator} />
-            <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_CREATE_PATCH', requestId: generateId(), repoId: commit.repoId, hash: commit.hash })}>
+            <div
+              data-ctx-item=""
+              style={ctxStyles.item}
+              onClick={() =>
+                send({
+                  type: "LOG_CREATE_PATCH",
+                  requestId: generateId(),
+                  repoId: commit.repoId,
+                  hash: commit.hash,
+                })
+              }
+            >
               <Codicon name="diff" style={ctxStyles.icon} />
               <span>Create Patch...</span>
             </div>
-            <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_CHERRY_PICK', requestId: generateId(), repoId: commit.repoId, hash: commit.hash })}>
+            <div
+              data-ctx-item=""
+              style={ctxStyles.item}
+              onClick={() =>
+                send({
+                  type: "/a",
+                  requestId: generateId(),
+                  repoId: commit.repoId,
+                  hash: commit.hash,
+                })
+              }
+            >
               <Codicon name="git-commit" style={ctxStyles.icon} />
               <span>Cherry-Pick</span>
             </div>
@@ -1087,23 +1246,62 @@ function CommitContextMenu({ commit, x, y, multiSelected, allCommits, currentBra
             <div
               data-ctx-item=""
               style={ctxStyles.item}
-              onClick={() => send({ type: 'LOG_RESET_TO_PICK', repoId: commit.repoId, hash: commit.hash } satisfies LogToHostMsg)}
+              onClick={() =>
+                send({
+                  type: "LOG_RESET_TO_PICK",
+                  repoId: commit.repoId,
+                  hash: commit.hash,
+                } satisfies LogToHostMsg)
+              }
             >
               <Codicon name="history" style={ctxStyles.icon} />
               <span>Reset Current Branch to Here...</span>
             </div>
-            <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_REVERT_COMMIT', requestId: generateId(), repoId: commit.repoId, hash: commit.hash })}>
+            <div
+              data-ctx-item=""
+              style={ctxStyles.item}
+              onClick={() =>
+                send({
+                  type: "LOG_REVERT_COMMIT",
+                  requestId: generateId(),
+                  repoId: commit.repoId,
+                  hash: commit.hash,
+                })
+              }
+            >
               <Codicon name="discard" style={ctxStyles.icon} />
               <span>Revert Commit</span>
             </div>
             {commit.unpushed && isHead && (
               <>
                 <div style={ctxStyles.separator} />
-                <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_EDIT_COMMIT_MESSAGE', requestId: generateId(), repoId: commit.repoId, hash: commit.hash, currentMessage: commit.message })}>
+                <div
+                  data-ctx-item=""
+                  style={ctxStyles.item}
+                  onClick={() =>
+                    send({
+                      type: "LOG_EDIT_COMMIT_MESSAGE",
+                      requestId: generateId(),
+                      repoId: commit.repoId,
+                      hash: commit.hash,
+                      currentMessage: commit.message,
+                    })
+                  }
+                >
                   <Codicon name="edit" style={ctxStyles.icon} />
                   <span>Edit Commit Message</span>
                 </div>
-                <div data-ctx-item="" style={ctxStyles.item} onClick={() => send({ type: 'LOG_UNDO_COMMIT', requestId: generateId(), repoId: commit.repoId })}>
+                <div
+                  data-ctx-item=""
+                  style={ctxStyles.item}
+                  onClick={() =>
+                    send({
+                      type: "LOG_UNDO_COMMIT",
+                      requestId: generateId(),
+                      repoId: commit.repoId,
+                    })
+                  }
+                >
                   <Codicon name="arrow-left" style={ctxStyles.icon} />
                   <span>Undo Commit</span>
                 </div>
@@ -1113,8 +1311,19 @@ function CommitContextMenu({ commit, x, y, multiSelected, allCommits, currentBra
               <>
                 <div style={ctxStyles.separator} />
                 <div
-                  data-ctx-item="" style={{ ...ctxStyles.item, color: 'var(--vscode-errorForeground)' }}
-                  onClick={() => send({ type: 'LOG_DROP_COMMIT', requestId: generateId(), repoId: commit.repoId, hash: commit.hash })}
+                  data-ctx-item=""
+                  style={{
+                    ...ctxStyles.item,
+                    color: "var(--vscode-errorForeground)",
+                  }}
+                  onClick={() =>
+                    send({
+                      type: "LOG_DROP_COMMIT",
+                      requestId: generateId(),
+                      repoId: commit.repoId,
+                      hash: commit.hash,
+                    })
+                  }
                 >
                   <Codicon name="trash" style={ctxStyles.icon} />
                   <span>Drop Commit</span>


### PR DESCRIPTION
Users can now right-click an individual changed file in a commit and choose Cherry-Pick Selected Changes to apply only that file’s changes from the commit into the current working tree, similar to JetBrains IDEs.

Changes

• Added Cherry-Pick Selected Changes to the commit file context menu.
• Reused the existing cherry-pick  git-commit  icon for consistency.
• Added a new  LOG_CHERRY_PICK_FILE  webview-to-host message.
• Implemented host-side handling for file-level cherry-pick operations.
• Added Git service support for applying a single file’s commit diff with  git apply --3way .
• Supports renamed files by passing the original path when available.
• Shows success, error, and conflict notifications in VS Code.
• Updated the README Git Log feature list.

Closes #21 