### PR TITLE
Add filter for repositories with changes

### DIFF
--- a/src/host/panels/CommitPanelProvider.ts
+++ b/src/host/panels/CommitPanelProvider.ts
@@ -26,6 +26,7 @@ import { logInfo, logWarn, logError, showLogChannel } from '../utils/Logger';
 
 export class CommitPanelProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'gitcharm.commitPanel';
+  private static readonly SHOW_ONLY_CHANGED_REPOS_KEY = 'gitcharm.showOnlyChangedRepos';
   private view?: vscode.WebviewView;
   private logProvider?: GitLogPanelProvider;
   private undockedPanel?: UndockedPanelProvider;
@@ -175,6 +176,7 @@ export class CommitPanelProvider implements vscode.WebviewViewProvider {
     // Refresh status whenever the panel becomes visible (e.g. user switches to it)
     webviewView.onDidChangeVisibility(() => {
       if (webviewView.visible) {
+        this.postRepoFilterState();
         this.manager.getAllStatuses().then(status => {
           this.postChangelistsUpdate(status);
           this.post({ type: 'COMMIT_STATUS_UPDATE', repos: this.manager.getRepoMetas(), status });
@@ -188,6 +190,7 @@ export class CommitPanelProvider implements vscode.WebviewViewProvider {
       this.postChangelistsUpdate(status);
       this.post({ type: 'COMMIT_STATUS_UPDATE', repos: this.manager.getRepoMetas(), status, fileViewMode: this.getFileViewMode() });
       this.post({ type: 'COMMIT_HIDDEN_REPOS_UPDATE', hiddenRepoIds: this.getHiddenRepoIds() });
+      this.postRepoFilterState();
       loadIconTheme(webviewView.webview).then(iconTheme => {
         this.post({ type: 'COMMIT_STATUS_UPDATE', repos: this.manager.getRepoMetas(), status, iconTheme, fileViewMode: this.getFileViewMode() });
       }).catch(() => { /* icon theme optional */ });
@@ -296,6 +299,19 @@ export class CommitPanelProvider implements vscode.WebviewViewProvider {
 
   private getFileViewMode(): 'flat' | 'tree' {
     return this.globalState?.get<'flat' | 'tree'>('fileViewMode', 'tree') ?? 'tree';
+  }
+
+  private getShowOnlyChangedRepos(): boolean {
+    return this.globalState?.get<boolean>(CommitPanelProvider.SHOW_ONLY_CHANGED_REPOS_KEY, false) ?? false;
+  }
+
+  private postRepoFilterState(): void {
+    this.post({ type: 'COMMIT_REPO_FILTER_UPDATE', showOnlyChangedRepos: this.getShowOnlyChangedRepos() });
+  }
+
+  private async setShowOnlyChangedRepos(showOnlyChangedRepos: boolean): Promise<void> {
+    await this.globalState?.update(CommitPanelProvider.SHOW_ONLY_CHANGED_REPOS_KEY, showOnlyChangedRepos);
+    this.postRepoFilterState();
   }
 
   private getDefaultCommitAction(): 'commit' | 'commitAndPush' {
@@ -450,6 +466,7 @@ export class CommitPanelProvider implements vscode.WebviewViewProvider {
           this.view ? loadIconTheme(this.view.webview) : Promise.resolve(undefined),
         ]);
         this.post({ type: 'COMMIT_STATUS_UPDATE', repos, status, iconTheme });
+        this.postRepoFilterState();
         this.postChangelistsUpdate(status);
         break;
       }
@@ -1845,6 +1862,11 @@ export class CommitPanelProvider implements vscode.WebviewViewProvider {
 
       case 'COMMIT_SET_FILE_VIEW_MODE': {
         await this.globalState?.update('fileViewMode', msg.mode);
+        break;
+      }
+
+      case 'COMMIT_SET_REPO_FILTER': {
+        await this.setShowOnlyChangedRepos(msg.showOnlyChangedRepos);
         break;
       }
 

--- a/src/host/types/messages.ts
+++ b/src/host/types/messages.ts
@@ -87,6 +87,7 @@ export type HostToCommitMsg =
   | { type: 'WORKTREE_LIST_RESULT'; repos: Array<{ repoId: string; repoName: string; repoColor: string; worktrees: WorktreeEntry[]; isLinkedWorktree: boolean }> }
   | { type: 'WORKTREE_OP_RESULT'; requestId: string; repoId: string; op: 'create' | 'delete' | 'prune' | 'lock' | 'unlock'; ok: boolean; error?: string }
   | { type: 'COMMIT_HIDDEN_REPOS_UPDATE'; hiddenRepoIds: string[] }
+  | { type: 'COMMIT_REPO_FILTER_UPDATE'; showOnlyChangedRepos: boolean }
   | { type: 'COMMIT_SWITCH_TAB'; tab: 'changes' | 'shelf' | 'stash' | 'worktree' | 'push' }
   | { type: 'COMMIT_DESELECT_FILE'; filePath: string };
 
@@ -160,6 +161,7 @@ export type CommitToHostMsg =
   | { type: 'CHANGELISTS_SHELVE'; changelistId: string; requestId: string }
   | { type: 'CHANGELISTS_STASH'; changelistId: string; requestId: string }
   | { type: 'COMMIT_SET_FILE_VIEW_MODE'; mode: 'flat' | 'tree' }
+  | { type: 'COMMIT_SET_REPO_FILTER'; showOnlyChangedRepos: boolean }
   | { type: 'SUBMODULE_INIT'; requestId: string; parentRepoId: string; submodulePath: string }
   | { type: 'SUBMODULE_DEINIT'; requestId: string; parentRepoId: string; submodulePath: string; force?: boolean }
   | { type: 'SUBMODULE_UPDATE'; requestId: string; parentRepoId: string; submodulePath: string; recursive?: boolean }

--- a/src/host/utils/webviewHtml.ts
+++ b/src/host/utils/webviewHtml.ts
@@ -55,23 +55,26 @@ export function getWebviewHtml(
       -webkit-appearance: none;
       width: 14px;
       height: 14px;
-      border: 1.5px solid var(--vscode-focusBorder, #007fd4);
+      border: 1px solid #b3b3b3;
       border-radius: 3px;
       background: transparent;
       cursor: pointer;
       flex-shrink: 0;
       position: relative;
       vertical-align: middle;
-      transition: background 0.12s, border-color 0.12s, box-shadow 0.12s;
+      opacity: 0.72;
+      transition: background 0.12s, border-color 0.12s, box-shadow 0.12s, opacity 0.12s;
     }
     input[type="checkbox"]:hover {
-      background: var(--vscode-focusBorder, #007fd4)22;
-      box-shadow: 0 0 0 2px var(--vscode-focusBorder, #007fd4)33;
+      background: #b3b3b322;
+      border-color: #d2d2d2;
+      box-shadow: 0 0 0 2px #b3b3b333;
+      opacity: 0.95;
     }
     input[type="checkbox"]:checked,
     input[type="checkbox"]:indeterminate {
-      background: var(--vscode-focusBorder, #007fd4);
-      border-color: var(--vscode-focusBorder, #007fd4);
+      background: #b3b3b3;
+      border-color: #b3b3b3;
     }
     input[type="checkbox"]:checked::after {
       content: '';
@@ -80,7 +83,7 @@ export function getWebviewHtml(
       top: 0px;
       width: 4px;
       height: 8px;
-      border: 2px solid #fff;
+      border: 1.5px solid #4d4d4d;
       border-top: none;
       border-left: none;
       transform: rotate(45deg);
@@ -92,11 +95,11 @@ export function getWebviewHtml(
       top: 5px;
       width: 8px;
       height: 2px;
-      background: #fff;
+      background: #4d4d4d;
       border-radius: 1px;
     }
     input[type="checkbox"]:focus-visible {
-      outline: 1px solid var(--vscode-focusBorder);
+      outline: 1px solid #d2d2d2;
       outline-offset: 2px;
     }
     input[type="checkbox"]:disabled {

--- a/src/webview/commitPanel/components/ChangelistGroup.tsx
+++ b/src/webview/commitPanel/components/ChangelistGroup.tsx
@@ -91,6 +91,7 @@ export function ChangelistGroup({
         <input
           ref={checkboxRef}
           type="checkbox"
+          className="gitcharm-subtle-checkbox"
           checked={allSelected}
           onChange={() => {}}
           onClick={totalFiles > 0 ? toggleAll : e => e.stopPropagation()}
@@ -246,6 +247,7 @@ function RepoSubGroup({
           <input
             ref={checkboxRef}
             type="checkbox"
+            className="gitcharm-subtle-checkbox"
             checked={allSelected}
             onChange={() => {}}
             onClick={totalFiles > 0 ? toggleAll : e => e.stopPropagation()}
@@ -343,7 +345,6 @@ const styles = {
   clCheckbox: {
     margin: '0 0 0 3px',
     flexShrink: 0,
-    accentColor: 'var(--vscode-button-background)',
   } as React.CSSProperties,
 
   headerMain: {
@@ -422,7 +423,6 @@ const styles = {
   repoCheckbox: {
     margin: '0 0 0 18px',
     flexShrink: 0,
-    accentColor: 'var(--vscode-button-background)',
   } as React.CSSProperties,
 
   repoHeaderMain: {

--- a/src/webview/commitPanel/components/CommitForm.tsx
+++ b/src/webview/commitPanel/components/CommitForm.tsx
@@ -67,6 +67,7 @@ export function CommitForm({
         <label style={styles.amendLabel}>
           <input
             type="checkbox"
+            className="gitcharm-subtle-checkbox"
             checked={amend}
             onChange={(e) => onAmendChange(e.target.checked)}
             disabled={loading}

--- a/src/webview/commitPanel/components/FileTree.tsx
+++ b/src/webview/commitPanel/components/FileTree.tsx
@@ -115,7 +115,7 @@ function Checkbox({ checked, indeterminate, onChange, onClick }: {
     if (ref.current) ref.current.indeterminate = indeterminate ?? false;
   }, [indeterminate]);
   return (
-    <input ref={ref} type="checkbox" checked={checked}
+    <input ref={ref} type="checkbox" className="gitcharm-subtle-checkbox" checked={checked}
       onChange={onChange} onClick={onClick} style={styles.checkbox} />
   );
 }
@@ -273,7 +273,7 @@ export function FileTree({ repoId, files, iconTheme, selectedFile, ctxFile, onSe
 
 const styles = {
   container: { display: 'flex', flexDirection: 'column' as const },
-  checkbox: { flexShrink: 0, margin: '0 3px 0 0', accentColor: 'var(--vscode-button-background)' } as React.CSSProperties,
+  checkbox: { flexShrink: 0, margin: '0 3px 0 0' } as React.CSSProperties,
   row: (selected: boolean, ctxActive = false, hovered = false): React.CSSProperties => ({
     display: 'flex',
     alignItems: 'center',

--- a/src/webview/commitPanel/components/ProjectGroup.tsx
+++ b/src/webview/commitPanel/components/ProjectGroup.tsx
@@ -88,6 +88,7 @@ export function ProjectGroup({
         <input
           ref={checkboxRef}
           type="checkbox"
+          className="gitcharm-subtle-checkbox"
           checked={allSelected}
           onChange={totalFiles > 0 ? toggleAll : () => {}}
           onClick={(e) => e.stopPropagation()}
@@ -234,7 +235,6 @@ const styles = {
   repoCheckbox: {
     margin: '0 0 0 6px',
     flexShrink: 0,
-    accentColor: 'var(--vscode-button-background)',
   } as React.CSSProperties,
   headerMain: {
     display: 'flex',

--- a/src/webview/commitPanel/components/PushTab.tsx
+++ b/src/webview/commitPanel/components/PushTab.tsx
@@ -503,11 +503,12 @@ function RepoSection({ repoStatus, repoMeta, unpushed, checked, canCheck, onTogg
         {!singleRepo && (
           <input
             type="checkbox"
+            className="gitcharm-subtle-checkbox"
             checked={checked}
             disabled={!canCheck}
             onChange={() => onToggle(repoStatus.repoId)}
             onClick={e => e.stopPropagation()}
-            style={{ ...styles.checkbox, opacity: canCheck ? 1 : 0.35, cursor: canCheck ? 'pointer' : 'default' }}
+            style={{ ...styles.checkbox, cursor: canCheck ? 'pointer' : 'default' }}
             title={!canCheck ? 'Nothing to push' : checked ? 'Exclude from push' : 'Include in push'}
           />
         )}
@@ -879,7 +880,6 @@ const styles = {
   }),
   checkbox: {
     margin: '0 2px 0 0', flexShrink: 0,
-    accentColor: 'var(--vscode-button-background)',
   } as React.CSSProperties,
   headerMain: {
     display: 'flex', alignItems: 'center', gap: '6px',

--- a/src/webview/commitPanel/components/RollbackModal.tsx
+++ b/src/webview/commitPanel/components/RollbackModal.tsx
@@ -57,7 +57,7 @@ function Checkbox({ checked, indeterminate, onChange, onClick }: {
 }) {
   const ref = useRef<HTMLInputElement>(null);
   useEffect(() => { if (ref.current) ref.current.indeterminate = indeterminate ?? false; }, [indeterminate]);
-  return <input ref={ref} type="checkbox" checked={checked} onChange={onChange} onClick={onClick} style={s.checkbox} />;
+  return <input ref={ref} type="checkbox" className="gitcharm-subtle-checkbox" checked={checked} onChange={onChange} onClick={onClick} style={s.checkbox} />;
 }
 
 // ── Dir node ──────────────────────────────────────────────────────────────────

--- a/src/webview/commitPanel/components/UnifiedCommitForm.tsx
+++ b/src/webview/commitPanel/components/UnifiedCommitForm.tsx
@@ -323,6 +323,7 @@ export function UnifiedCommitForm({
         <label style={styles.amendLabel} title="Modify the last commit instead of creating a new one. Rewrites history — avoid on shared branches.">
           <input
             type="checkbox"
+            className="gitcharm-subtle-checkbox"
             checked={amend}
             onChange={() => onAmendToggle(amendRepoId!)}
             style={{ margin: '0 4px 0 0' }}

--- a/src/webview/commitPanel/components/VscodeView.tsx
+++ b/src/webview/commitPanel/components/VscodeView.tsx
@@ -327,12 +327,13 @@ function VscodeRepoGroup({ repoStatus, repoName, repoColor, staged, files, viewM
           {staged && onToggleRepoSelection && (
             <input
               type="checkbox"
+              className="gitcharm-subtle-checkbox"
               checked={isEmpty ? false : (repoSelected ?? true)}
               onChange={e => { if (!isEmpty) { e.stopPropagation(); onToggleRepoSelection?.(); } }}
               onClick={e => e.stopPropagation()}
               title={isEmpty ? undefined : "Include this repository in the commit"}
               disabled={isEmpty}
-              style={{ margin: '0 0 0 8px', flexShrink: 0, accentColor: 'var(--vscode-button-background)', cursor: isEmpty ? 'default' : 'pointer', ...(isEmpty ? { opacity: 0.3, pointerEvents: 'none' } : {}) }}
+              style={{ margin: '0 0 0 8px', flexShrink: 0, cursor: isEmpty ? 'default' : 'pointer', ...(isEmpty ? { opacity: 0.3, pointerEvents: 'none' } : {}) }}
             />
           )}
           <div style={repoHeaderMainStyle} onClick={() => toggleCollapsed(collapseKey)}>

--- a/src/webview/commitPanel/main.tsx
+++ b/src/webview/commitPanel/main.tsx
@@ -360,6 +360,71 @@ function App() {
     document.head.appendChild(s);
   }, []);
 
+  useEffect(() => {
+    const id = 'gitcharm-subtle-checkbox';
+    if (document.getElementById(id)) return;
+    const s = document.createElement('style');
+    s.id = id;
+    s.textContent = `
+      .gitcharm-subtle-checkbox {
+        appearance: none !important;
+        -webkit-appearance: none !important;
+        width: 14px !important;
+        height: 14px !important;
+        box-sizing: border-box !important;
+        padding: 0 !important;
+        border: 1px solid #b3b3b3 !important;
+        border-radius: 3px !important;
+        background: transparent !important;
+        position: relative !important;
+        cursor: pointer !important;
+        opacity: 0.72 !important;
+      }
+      .gitcharm-subtle-checkbox:hover {
+        border-color: #d2d2d2 !important;
+        background: #b3b3b322 !important;
+        box-shadow: 0 0 0 2px #b3b3b333 !important;
+        opacity: 0.95 !important;
+      }
+      .gitcharm-subtle-checkbox:checked {
+        background: #b3b3b3 !important;
+        border-color: #b3b3b3 !important;
+      }
+      .gitcharm-subtle-checkbox:checked::after {
+        content: '' !important;
+        position: absolute !important;
+        left: 3px !important;
+        top: 1px !important;
+        width: 4px !important;
+        height: 7px !important;
+        border: solid #4d4d4d !important;
+        border-width: 0 1.5px 1.5px 0 !important;
+        transform: rotate(45deg) !important;
+      }
+      .gitcharm-subtle-checkbox:indeterminate {
+        background: #b3b3b3 !important;
+      }
+      .gitcharm-subtle-checkbox:indeterminate::after {
+        content: '' !important;
+        position: absolute !important;
+        left: 3px !important;
+        top: 6px !important;
+        width: 6px !important;
+        height: 1.5px !important;
+        background: #4d4d4d !important;
+      }
+      .gitcharm-subtle-checkbox:focus-visible {
+        outline: 1px solid #d2d2d2 !important;
+        outline-offset: 1px !important;
+      }
+      .gitcharm-subtle-checkbox:disabled {
+        cursor: default !important;
+        opacity: 0.35 !important;
+      }
+    `;
+    document.head.appendChild(s);
+  }, []);
+
   // ── Autopilot ─────────────────────────────────────────────────────────────
   const [generatingMessage, setGeneratingMessage]   = useState(false);
 

--- a/src/webview/commitPanel/main.tsx
+++ b/src/webview/commitPanel/main.tsx
@@ -285,6 +285,9 @@ function App() {
   // ── Hidden repositories ───────────────────────────────────────────────────
   const [hiddenRepoIds, setHiddenRepoIds] = useState<string[]>([]);
 
+  // ── Changes view filters ──────────────────────────────────────────────────
+  const [showOnlyChangedRepos, setShowOnlyChangedRepos] = useState(false);
+
   // ── Submodule detached HEAD warnings ─────────────────────────────────────
   // repoId → headCommit — shown as dismissable banner above the file tree
   const [detachedWarnings, setDetachedWarnings] = useState<Record<string, string>>({});
@@ -696,9 +699,13 @@ function App() {
 
   const allRepos = store.status?.repos ?? [];
   const repos = hiddenRepoIds.length > 0 ? allRepos.filter(r => !hiddenRepoIds.includes(r.repoId)) : allRepos;
+  const changedRepos = repos.filter(r => r.stagedFiles.length > 0 || r.unstagedFiles.length > 0);
+  const changesRepos = showOnlyChangedRepos ? changedRepos : repos;
   const metaMap = new Map(store.repoMetas.map(m => [m.id, m]));
   const multiRepo = repos.length >= 1;
   const singleRepo = repos.length === 1;
+  const changesMultiRepo = changesRepos.length >= 1;
+  const changesSingleRepo = changesRepos.length === 1;
 
   // Keep unpushed-commit counts fresh for repos without upstream so the Push tab badge
   // shows the correct number even before the tab is opened. Upstream repos are live via aheadBehind.ahead.
@@ -907,7 +914,7 @@ function App() {
         send({ type: 'COMMIT_REQUEST_STATUS' });
         break;
     }
-  }, [clHeaderCtxMenu, store.changelists, send]);
+  }, [clHeaderCtxMenu, store.changelists, changesRepos, send]);
 
   // ── Push actions ──────────────────────────────────────────────────────────
 
@@ -1152,6 +1159,15 @@ function App() {
                 </div>
               )}
             </div>
+            <button
+              data-action-btn=""
+              style={{ ...css.iconBtn, ...(showOnlyChangedRepos ? css.activeIconBtn : {}) }}
+              title={showOnlyChangedRepos ? 'Show all repositories' : 'Show only repositories with changes'}
+              aria-pressed={showOnlyChangedRepos}
+              onClick={() => setShowOnlyChangedRepos(value => !value)}
+            >
+              <Codicon name="filter" />
+            </button>
           </>)}
           {activeTab === 'shelf' && (<>
             <button data-action-btn="" style={css.iconBtn} title="Expand all" onClick={() => {
@@ -1304,9 +1320,17 @@ function App() {
 
           {/* File list */}
           <ScrollArea style={css.repoList}>
-            {store.changesViewMode === 'vscode' ? (
+            {showOnlyChangedRepos && changesRepos.length === 0 ? (
+              <div style={css.filteredEmptyState}>
+                <Codicon name="filter" style={{ fontSize: '18px', opacity: 0.55 }} />
+                <div>No repositories with changes</div>
+                <button style={css.clearFilterBtn} onClick={() => setShowOnlyChangedRepos(false)}>
+                  Show all repositories
+                </button>
+              </div>
+            ) : store.changesViewMode === 'vscode' ? (
               <VscodeView
-                repos={repos}
+                repos={changesRepos}
                 repoMetas={store.repoMetas}
                 selectedFile={selectedFile ? { repoId: selectedFile.repoId, path: selectedFile.path } : null}
                 ctxFile={ctxFile}
@@ -1365,7 +1389,7 @@ function App() {
             ) : store.changesViewMode === 'changelists' ? (
               <ChangelistView
                 changelists={store.changelists}
-                repos={repos}
+                repos={changesRepos}
                 repoMetas={store.repoMetas}
                 selectedFile={selectedFile ? { repoId: selectedFile.repoId, path: selectedFile.path } : null}
                 viewMode={store.viewMode}
@@ -1413,7 +1437,7 @@ function App() {
                 multiSelectedFiles={multiSelectedFiles}
               />
             ) : (
-              repos.map((repoStatus, idx) => {
+              changesRepos.map((repoStatus, idx) => {
                 const repoId = repoStatus.repoId;
                 const meta = metaMap.get(repoId);
                 const repoName = meta?.name ?? repoId.split('/').pop() ?? repoId;
@@ -1448,8 +1472,8 @@ function App() {
                       repoStatus={repoStatus}
                       repoName={repoName}
                       repoColor={repoColor}
-                      multiRepo={multiRepo}
-                      singleRepo={singleRepo}
+                      multiRepo={changesMultiRepo}
+                      singleRepo={changesSingleRepo}
                       isSubmodule={meta?.isSubmodule}
                       submodulePath={meta?.submodulePath}
                       isWorktree={meta?.isWorktree}
@@ -1536,7 +1560,7 @@ function App() {
           {/* Commit form */}
           <UnifiedCommitForm
             message={store.commitMessage}
-            repoStatuses={repos}
+            repoStatuses={changesRepos}
             repoMetas={store.repoMetas}
             amendFlags={store.amendFlags}
             loading={store.loading}
@@ -1549,7 +1573,7 @@ function App() {
               if (store.changesViewMode === 'vscode') {
                 toggleVscodeRepoSelection(repoId);
               } else {
-                const r = repos.find(r => r.repoId === repoId);
+                const r = changesRepos.find(r => r.repoId === repoId);
                 if (!r) return;
                 const allPaths = [...r.stagedFiles, ...r.unstagedFiles].map(f => f.path);
                 store.setFileSelections(repoId, allPaths, false);
@@ -1576,7 +1600,7 @@ function App() {
             onShelve={() => {
               const name = store.commitMessage.trim();
               if (!name) return;
-              for (const repoStatus of repos) {
+              for (const repoStatus of changesRepos) {
                 const selectedPaths = store.getSelectedFilesForRepo(repoStatus.repoId);
                 if (selectedPaths.length === 0) continue;
                 confirmShelve(repoStatus.repoId, name, selectedPaths);
@@ -1585,7 +1609,7 @@ function App() {
             }}
             onStash={() => {
               const message = store.commitMessage.trim() || 'WIP stash';
-              for (const repoStatus of repos) {
+              for (const repoStatus of changesRepos) {
                 const selectedPaths = store.getSelectedFilesForRepo(repoStatus.repoId);
                 if (selectedPaths.length === 0) continue;
                 doStash(repoStatus.repoId, message, selectedPaths);
@@ -1981,7 +2005,7 @@ function App() {
               : CHANGELIST_HEADER_ITEMS_CUSTOM;
         const clFileCount = (() => {
           if (isEmpty) return 0;
-          if (isUnversioned) return repos.reduce((sum, r) => sum + r.unstagedFiles.filter(f => f.status === 'untracked').length, 0);
+          if (isUnversioned) return changesRepos.reduce((sum, r) => sum + r.unstagedFiles.filter(f => f.status === 'untracked').length, 0);
           const cl = store.changelists.find(c => c.id === clHeaderCtxMenu.changelistId);
           if (!cl) return 0;
           return Object.values(cl.fileAssignments).reduce((sum, paths) => sum + paths.length, 0);
@@ -2019,6 +2043,11 @@ const css = {
     background: 'transparent', border: 'none', color: 'var(--vscode-foreground)',
     cursor: 'pointer', padding: '4px 5px', borderRadius: '3px',
     fontSize: '14px', display: 'flex', alignItems: 'center', opacity: 0.8,
+  } as React.CSSProperties,
+  activeIconBtn: {
+    background: 'var(--vscode-toolbar-activeBackground, var(--vscode-toolbar-hoverBackground))',
+    color: 'var(--vscode-textLink-foreground, var(--vscode-foreground))',
+    opacity: 1,
   } as React.CSSProperties,
   dropdownPanel: {
     position: 'absolute' as const, top: '100%', left: 0, zIndex: 1000,
@@ -2080,6 +2109,17 @@ const css = {
   } as React.CSSProperties,
   main: { display: 'flex', flexDirection: 'column' as const, flex: 1, overflow: 'hidden' },
   repoList: { flex: 1, minHeight: 0 },
+  filteredEmptyState: {
+    display: 'flex', flexDirection: 'column' as const, alignItems: 'center', gap: '10px',
+    padding: '32px 16px', color: 'var(--vscode-foreground)', opacity: 0.7,
+    fontSize: '12px', textAlign: 'center' as const,
+  } as React.CSSProperties,
+  clearFilterBtn: {
+    background: 'var(--vscode-button-secondaryBackground, var(--vscode-button-background))',
+    color: 'var(--vscode-button-secondaryForeground, var(--vscode-button-foreground))',
+    border: 'none', borderRadius: '3px', padding: '4px 9px', cursor: 'pointer',
+    fontSize: '11px',
+  } as React.CSSProperties,
   // Shelve name prompt bar (above commit form)
   detachedBanner: {
     display: 'flex', alignItems: 'center', gap: '6px', padding: '5px 8px',

--- a/src/webview/commitPanel/main.tsx
+++ b/src/webview/commitPanel/main.tsx
@@ -456,6 +456,11 @@ function App() {
     getVsCodeApi().postMessage(msg);
   }, []);
 
+  const setRepoFilter = useCallback((showOnlyChangedRepos: boolean) => {
+    setShowOnlyChangedRepos(showOnlyChangedRepos);
+    send({ type: 'COMMIT_SET_REPO_FILTER', showOnlyChangedRepos });
+  }, [send]);
+
   // Close view-menus on outside click
   useEffect(() => {
     const h = (e: MouseEvent) => {
@@ -487,6 +492,9 @@ function App() {
       }
 
       switch (msg.type) {
+        case 'COMMIT_REPO_FILTER_UPDATE':
+          setShowOnlyChangedRepos(msg.showOnlyChangedRepos);
+          break;
         case 'COMMIT_STATUS_UPDATE':
           store.setStatus(msg.repos, msg.status, msg.iconTheme, msg.fileViewMode, msg.defaultCommitAction, msg.defaultSaveAction, msg.hasWorkspaceFolder, msg.aiEnabled, msg.activeProfile);
           if (Array.isArray(msg.status.repos) && useCommitStore.getState().changesViewMode === 'vscode') {
@@ -1229,7 +1237,7 @@ function App() {
               style={{ ...css.iconBtn, ...(showOnlyChangedRepos ? css.activeIconBtn : {}) }}
               title={showOnlyChangedRepos ? 'Show all repositories' : 'Show only repositories with changes'}
               aria-pressed={showOnlyChangedRepos}
-              onClick={() => setShowOnlyChangedRepos(value => !value)}
+              onClick={() => setRepoFilter(!showOnlyChangedRepos)}
             >
               <Codicon name="filter" />
             </button>
@@ -1389,7 +1397,7 @@ function App() {
               <div style={css.filteredEmptyState}>
                 <Codicon name="filter" style={{ fontSize: '18px', opacity: 0.55 }} />
                 <div>No repositories with changes</div>
-                <button style={css.clearFilterBtn} onClick={() => setShowOnlyChangedRepos(false)}>
+                <button style={css.clearFilterBtn} onClick={() => setRepoFilter(false)}>
                   Show all repositories
                 </button>
               </div>


### PR DESCRIPTION
## Summary
- Add a Changes-tab toolbar toggle to show only repositories with staged or unstaged changes.
- Keep the filter scoped to the Changes tab so Shelf, Stash, and Push views are unchanged.
- Add a clear-filter empty state when no repositories currently have changes.

## Verification
- `npm run typecheck`
- `npm run typecheck:webview`
- `npm run build`
- VSIX packaged and installed locally in VS Code

Full lint currently reports pre-existing errors elsewhere in the repository.