### PR TITLE
Make branch sidebar pull and push branch-aware

### DIFF
--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -1153,6 +1153,31 @@ export class GitService {
     await this.git.remote(['set-url', name, url]);
   }
 
+  async getBranchUpstream(branchName: string): Promise<{ remote: string; branchName: string } | null> {
+    const localRef = `refs/heads/${branchName}`;
+    const raw = await this.git.raw([
+      'for-each-ref',
+      '--format=%(upstream:remotename)%00%(upstream:remoteref)',
+      localRef,
+    ]).catch(() => '');
+    const [remote, remoteRef] = raw.trim().split('\0');
+    if (!remote || remote === '.' || !remoteRef?.startsWith('refs/heads/')) return null;
+    return { remote, branchName: remoteRef.slice('refs/heads/'.length) };
+  }
+
+  async pushBranch(branchName: string, remote: string, remoteBranchName: string, setUpstream: boolean): Promise<void> {
+    const refspec = `refs/heads/${branchName}:refs/heads/${remoteBranchName}`;
+    const vsRepo = this.vsRepo();
+    if (vsRepo?.state.remotes.some(item => item.name === remote)) {
+      await vsRepo.push(remote, refspec, setUpstream);
+      return;
+    }
+    const args = ['push'];
+    if (setUpstream) args.push('--set-upstream');
+    args.push(remote, refspec);
+    await this.git.raw(args);
+  }
+
   async push(force = false, remote?: string): Promise<void> {
     const vsRepo = this.vsRepo();
     // Only use VS Code API when it actually knows the remotes for this repo.

--- a/src/host/panels/GitLogPanelProvider.ts
+++ b/src/host/panels/GitLogPanelProvider.ts
@@ -318,6 +318,30 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
     return all.filter(b => ids.has(b.repoId));
   }
 
+  private async pickBranchRepo(repoIds: string[], branchName: string, action: 'Pull' | 'Push'): Promise<string | null> {
+    const metas = new Map(this.manager.getRepoMetas().map(meta => [meta.id, meta]));
+    const candidates = Array.from(new Set(repoIds))
+      .filter(repoId => !!this.manager.getRepo(repoId))
+      .map(repoId => {
+        const meta = metas.get(repoId);
+        return {
+          label: `$(repo) ${meta?.name ?? repoId}`,
+          description: meta?.rootPath,
+          repoId,
+        };
+      });
+    if (candidates.length === 0) {
+      vscode.window.showWarningMessage(`No repository found for branch "${branchName}".`);
+      return null;
+    }
+    if (candidates.length === 1) return candidates[0].repoId;
+    const picked = await vscode.window.showQuickPick(candidates, {
+      title: `${action} "${branchName}" — Select repository`,
+      placeHolder: `Select the repository in which to ${action.toLowerCase()} this branch`,
+    });
+    return picked?.repoId ?? null;
+  }
+
   private async handleMessage(msg: LogToHostMsg): Promise<void> {
     switch (msg.type) {
       case 'LOG_REQUEST_COMMITS': {
@@ -566,6 +590,31 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
         break;
       }
 
+      case 'LOG_PULL_BRANCH_PICK': {
+        const repoId = await this.pickBranchRepo(msg.repoIds, msg.branchName, 'Pull');
+        if (!repoId) break;
+        const repo = this.manager.getRepo(repoId);
+        if (!repo) break;
+        const current = await repo.getCurrentBranch().catch(() => null);
+        if (!current || current.name !== msg.branchName || current.detachedTag || current.detachedHash) {
+          vscode.window.showWarningMessage(`Cannot pull "${msg.branchName}" because it is no longer the current branch.`);
+          break;
+        }
+        await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Notification, title: `Pulling "${msg.branchName}"`, cancellable: false },
+          async () => {
+            try {
+              await repo.pull();
+              this.post({ type: 'LOG_REFRESH' });
+            } catch (e: unknown) {
+              logError('pullBranch', formatGitError(e), getRawErrorDetail(e));
+              showGitError('pullBranch', e);
+            }
+          }
+        );
+        break;
+      }
+
       case 'LOG_PUSH': {
         const repo = this.manager.getRepo(msg.repoId);
         if (!repo) { this.post({ type: 'LOG_BRANCH_OP_RESULT', requestId: msg.requestId, ok: false, error: 'Repo not found' }); return; }
@@ -579,6 +628,52 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
             } catch (e: unknown) {
               logError('push', formatGitError(e), getRawErrorDetail(e));
               this.post({ type: 'LOG_BRANCH_OP_RESULT', requestId: msg.requestId, ok: false, error: formatGitError(e) });
+            }
+          }
+        );
+        break;
+      }
+
+      case 'LOG_PUSH_BRANCH_PICK': {
+        const repoId = await this.pickBranchRepo(msg.repoIds, msg.branchName, 'Push');
+        if (!repoId) break;
+        const repo = this.manager.getRepo(repoId);
+        if (!repo) break;
+        const branches = await repo.getBranches().catch(() => []);
+        if (!branches.some(branch => !branch.isRemote && branch.name === msg.branchName)) {
+          vscode.window.showWarningMessage(`Local branch "${msg.branchName}" was not found.`);
+          break;
+        }
+
+        const upstream = await repo.getBranchUpstream(msg.branchName);
+        let remote = upstream?.remote;
+        let remoteBranchName = upstream?.branchName ?? msg.branchName;
+        if (!remote) {
+          const remotes = await repo.getRemotes().catch(() => [] as string[]);
+          if (remotes.length === 0) {
+            vscode.window.showWarningMessage('No remotes configured.');
+            break;
+          }
+          remote = remotes.length === 1
+            ? remotes[0]
+            : (await vscode.window.showQuickPick(
+                remotes.map(name => ({ label: `$(cloud-upload) ${name}`, remote: name })),
+                { title: `Push "${msg.branchName}" — Select remote` }
+              ))?.remote;
+          if (!remote) break;
+          remoteBranchName = msg.branchName;
+        }
+
+        await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Notification, title: `Pushing "${msg.branchName}" to ${remote}`, cancellable: false },
+          async () => {
+            try {
+              await repo.pushBranch(msg.branchName, remote!, remoteBranchName, !upstream);
+              logInfo('pushBranch', `Pushed "${msg.branchName}" to "${remote}/${remoteBranchName}" successfully.`);
+              vscode.window.showInformationMessage(`Pushed "${msg.branchName}" to "${remote}/${remoteBranchName}" successfully.`);
+              this.post({ type: 'LOG_REFRESH' });
+            } catch (e: unknown) {
+              showGitError('pushBranch', e);
             }
           }
         );

--- a/src/host/types/messages.ts
+++ b/src/host/types/messages.ts
@@ -240,7 +240,9 @@ export type LogToHostMsg =
   | { type: 'LOG_CHERRY_PICK_FILE'; requestId: string; repoId: string; hash: string; filePath: string; oldPath?: string }
   | { type: 'LOG_CHECKOUT'; requestId: string; repoId: string; branchName: string; createNew?: boolean; from?: string }
   | { type: 'LOG_PULL'; requestId: string; repoId: string }
+  | { type: 'LOG_PULL_BRANCH_PICK'; repoIds: string[]; branchName: string }
   | { type: 'LOG_PUSH'; requestId: string; repoId: string; remote?: string; force?: boolean }
+  | { type: 'LOG_PUSH_BRANCH_PICK'; repoIds: string[]; branchName: string }
   | { type: 'LOG_MERGE'; requestId: string; repoId: string; from: string }
   | { type: 'LOG_REBASE'; requestId: string; repoId: string; onto: string }
   | { type: 'LOG_COMPARE'; requestId: string; repoId: string; refA: string; refB: string }

--- a/src/webview/gitLog/components/BranchSidebar.tsx
+++ b/src/webview/gitLog/components/BranchSidebar.tsx
@@ -18,8 +18,8 @@ interface Props {
   onRebase: (repoId: string, onto: string) => void;
   onDelete: (repoIds: string[], branchName: string) => void;
   onFetchRepo: (repoId: string) => void;
-  onPull: (repoId: string) => void;
-  onPush: (repoId: string) => void;
+  onPull: (repoIds: string[], branchName: string) => void;
+  onPush: (repoIds: string[], branchName: string) => void;
   onCheckoutTag: (repoIds: string[], tagName: string) => void;
   onMergeTag: (repoIds: string[], tagName: string) => void;
   onPushTag: (repoId: string, tagName: string) => void;
@@ -259,6 +259,9 @@ export const BranchSidebar = forwardRef<HTMLDivElement, Props>(function BranchSi
       {/* Branch context menu */}
       {contextMenu && (() => {
         const inst = primaryInstance(contextMenu.merged);
+        const localInstances = contextMenu.merged.instances.filter(instance => !instance.isRemote);
+        const currentLocalRepoIds = localInstances.filter(instance => instance.isHead).map(instance => instance.repoId);
+        const localRepoIds = localInstances.map(instance => instance.repoId);
         return (
           <ContextMenu
             merged={contextMenu.merged}
@@ -270,8 +273,8 @@ export const BranchSidebar = forwardRef<HTMLDivElement, Props>(function BranchSi
             onMerge={() => { onMerge(inst.repoId, inst.name); setContextMenu(null); }}
             onRebase={() => { onRebase(inst.repoId, inst.name); setContextMenu(null); }}
             onDelete={() => { onDelete(contextMenu.merged.repoIds, inst.name); setContextMenu(null); }}
-            onPull={() => { onPull(inst.repoId); setContextMenu(null); }}
-            onPush={() => { onPush(inst.repoId); setContextMenu(null); }}
+            onPull={currentLocalRepoIds.length > 0 ? () => { onPull(currentLocalRepoIds, contextMenu.merged.baseName); setContextMenu(null); } : undefined}
+            onPush={localRepoIds.length > 0 ? () => { onPush(localRepoIds, contextMenu.merged.baseName); setContextMenu(null); } : undefined}
           />
         );
       })()}
@@ -463,8 +466,8 @@ function ContextMenu({ merged, x, y, canDelete, onClose, onCheckout, onMerge, on
   onMerge: () => void;
   onRebase: () => void;
   onDelete: () => void;
-  onPull: () => void;
-  onPush: () => void;
+  onPull?: () => void;
+  onPush?: () => void;
 }) {
   const { ref, pos } = useClampedPosition(x, y);
   useEffect(() => {
@@ -485,9 +488,11 @@ function ContextMenu({ merged, x, y, canDelete, onClose, onCheckout, onMerge, on
     { sep: true },
     { icon: 'git-merge', label: 'Merge into current', action: onMerge },
     { icon: 'repo-forked', label: `Rebase onto "${merged.baseName}"`, action: onRebase },
-    { sep: true },
-    { icon: 'cloud-download', label: 'Pull', action: onPull },
-    { icon: 'cloud-upload', label: 'Push...', action: onPush },
+    ...(onPull || onPush ? [
+      { sep: true as const },
+      ...(onPull ? [{ icon: 'cloud-download', label: `Pull "${merged.baseName}"`, action: onPull }] : []),
+      ...(onPush ? [{ icon: 'cloud-upload', label: `Push "${merged.baseName}"...`, action: onPush }] : []),
+    ] : []),
     ...(canDelete ? [{ sep: true as const }, { icon: 'trash', label: 'Delete branch', action: onDelete, danger: true }] : []),
   ];
 

--- a/src/webview/gitLog/main.tsx
+++ b/src/webview/gitLog/main.tsx
@@ -403,12 +403,11 @@ function App() {
             const reqId = generateId();
             getVsCodeApi().postMessage({ type: 'LOG_FETCH_REPO', requestId: reqId, repoId } satisfies LogToHostMsg);
           }}
-          onPull={(repoId) => {
-            const reqId = generateId();
-            getVsCodeApi().postMessage({ type: 'LOG_PULL', requestId: reqId, repoId } satisfies LogToHostMsg);
+          onPull={(repoIds, branchName) => {
+            getVsCodeApi().postMessage({ type: 'LOG_PULL_BRANCH_PICK', repoIds, branchName } satisfies LogToHostMsg);
           }}
-          onPush={(repoId) => {
-            getVsCodeApi().postMessage({ type: 'LOG_PUSH_PICK', repoId } satisfies LogToHostMsg);
+          onPush={(repoIds, branchName) => {
+            getVsCodeApi().postMessage({ type: 'LOG_PUSH_BRANCH_PICK', repoIds, branchName } satisfies LogToHostMsg);
           }}
           onCheckoutTag={(repoIds, tagName) => {
             repoIds.forEach(repoId => {

--- a/src/webview/undockedPanel/main.tsx
+++ b/src/webview/undockedPanel/main.tsx
@@ -309,8 +309,8 @@ function LogApp() {
           onRebase={(repoId, onto) => getVsCodeApi().postMessage({ type: 'LOG_REBASE', requestId: generateId(), repoId, onto } satisfies LogToHostMsg)}
           onDelete={(repoIds, branchName) => getVsCodeApi().postMessage({ type: 'LOG_DELETE_BRANCH_MULTI', requestId: generateId(), repoIds, branchName } satisfies LogToHostMsg)}
           onFetchRepo={(repoId) => getVsCodeApi().postMessage({ type: 'LOG_FETCH_REPO', requestId: generateId(), repoId } satisfies LogToHostMsg)}
-          onPull={(repoId) => getVsCodeApi().postMessage({ type: 'LOG_PULL', requestId: generateId(), repoId } satisfies LogToHostMsg)}
-          onPush={(repoId) => getVsCodeApi().postMessage({ type: 'LOG_PUSH_PICK', repoId } satisfies LogToHostMsg)}
+          onPull={(repoIds, branchName) => getVsCodeApi().postMessage({ type: 'LOG_PULL_BRANCH_PICK', repoIds, branchName } satisfies LogToHostMsg)}
+          onPush={(repoIds, branchName) => getVsCodeApi().postMessage({ type: 'LOG_PUSH_BRANCH_PICK', repoIds, branchName } satisfies LogToHostMsg)}
           onCheckoutTag={(repoIds, tagName) => repoIds.forEach(repoId => getVsCodeApi().postMessage({ type: 'LOG_CHECKOUT_TAG', requestId: generateId(), repoId, tagName } satisfies LogToHostMsg))}
           onMergeTag={(repoIds, tagName) => getVsCodeApi().postMessage({ type: 'LOG_MERGE_TAG_MULTI', requestId: generateId(), repoIds, tagName } satisfies LogToHostMsg)}
           onPushTag={(repoId, tagName) => getVsCodeApi().postMessage({ type: 'LOG_PUSH_TAG_PICK', repoId, tagName } satisfies LogToHostMsg)}


### PR DESCRIPTION
## Problem

Pull and Push actions opened from a branch's context menu ignored the clicked branch and operated on the repository's currently checked-out branch instead. This made Push misleading for non-current branches and exposed Pull where it could not meaningfully apply.

## Summary

- Make Branch sidebar Pull and Push operate on the clicked local branch
- Show Pull only when the branch is currently checked out
- Allow pushing a non-current local branch without checking it out
- Hide Pull and Push for remote-only branch entries
- Use the clicked branch's configured upstream automatically
- Prompt for a remote and establish tracking when no upstream exists
- Prompt for a repository when a merged branch row represents multiple repositories
- Push explicit local and remote refs instead of deriving the branch from `HEAD`
- Use VS Code's Git API for known remotes so SSH credentials and passphrase prompts are handled correctly
- Retain raw Git as a fallback when the remote is unavailable through VS Code's Git API
- Revalidate that a branch is still current before pulling
- Apply the same behavior in the docked and undocked Git Log views

<img height="300" alt="image" src="https://github.com/user-attachments/assets/bb4720d4-d7e0-4fc3-a06b-0e3c5da25325" />

## Validation

- `npm run typecheck`
- `npm run typecheck:webview`
- `npm run build`
- `git diff --check`