### PR TITLE
Show changes between two selected commits

### DIFF
--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -16,8 +16,6 @@ import { parseDiff, buildMonacoContents, detectLanguage } from './DiffParser';
 import { getVscodeRepository } from './VscodeGitApi';
 import { ForcePushMode, Status, RefType } from './git.d';
 
-const EMPTY_TREE_HASH = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
-
 const STATUS_MAP: Record<string, GitFileStatus> = {
   M: 'modified', A: 'added', D: 'deleted',
   R: 'renamed', C: 'copied', U: 'conflicted',
@@ -742,8 +740,10 @@ export class GitService {
   }
 
   async getCombinedFiles(hashes: string[]): Promise<Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }>> {
-    const refs = await this._getInclusiveDiffRefs(hashes);
-    return refs ? this._getFilesBetweenRefs(refs.base, refs.newest) : [];
+    const ordered = await this._sortHashesOldestFirst(hashes);
+    const oldest = ordered[0];
+    const newest = ordered[ordered.length - 1];
+    return oldest && newest ? this._getFilesBetweenRefs(`${oldest}~1`, newest) : [];
   }
 
   async getFilesBetween(hashes: string[]): Promise<Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }>> {
@@ -785,19 +785,21 @@ export class GitService {
   }
 
   async getCombinedFileDiff(repoId: string, hashes: string[], filePath: string): Promise<FileDiff | null> {
-    const refs = await this._getInclusiveDiffRefs(hashes);
-    if (!refs) return null;
+    const ordered = await this._sortHashesOldestFirst(hashes);
+    const oldest = ordered[0];
+    const newest = ordered[ordered.length - 1];
+    if (!oldest || !newest) return null;
     try {
       const vsRepo = this.vsRepo();
-      const rawDiff = await this.git.raw(['diff', refs.base, refs.newest, '--', filePath, '--no-renames']);
+      const rawDiff = await this.git.raw(['diff', `${oldest}~1`, newest, '--', filePath, '--no-renames']);
       const diffs = parseDiff(rawDiff || `diff --git a/${filePath} b/${filePath}\n`, repoId);
       const diff = diffs[0] ?? { repoId, oldPath: filePath, newPath: filePath, isBinary: false, isNew: false, isDeleted: false, hunks: [] };
       if (vsRepo) {
-        diff.originalContent = refs.base === EMPTY_TREE_HASH ? '' : await vsRepo.show(refs.base, filePath).catch(() => '');
-        diff.modifiedContent = await vsRepo.show(refs.newest, filePath).catch(() => '');
+        diff.originalContent = await vsRepo.show(`${oldest}~1`, filePath).catch(() => '');
+        diff.modifiedContent = await vsRepo.show(newest, filePath).catch(() => '');
       } else {
-        diff.originalContent = refs.base === EMPTY_TREE_HASH ? '' : await this.git.raw(['show', `${refs.base}:${filePath}`]).catch(() => '');
-        diff.modifiedContent = await this.git.raw(['show', `${refs.newest}:${filePath}`]).catch(() => '');
+        diff.originalContent = await this.git.raw(['show', `${oldest}~1:${filePath}`]).catch(() => '');
+        diff.modifiedContent = await this.git.raw(['show', `${newest}:${filePath}`]).catch(() => '');
       }
       return diff;
     } catch { return null; }
@@ -825,15 +827,6 @@ export class GitService {
       if (p) files.push({ status: 'A', path: p });
     }
     return files;
-  }
-
-  private async _getInclusiveDiffRefs(hashes: string[]): Promise<{ base: string; newest: string } | null> {
-    const ordered = await this._sortHashesOldestFirst(hashes);
-    const oldest = ordered[0];
-    const newest = ordered[ordered.length - 1];
-    if (!oldest || !newest) return null;
-    const parents = await this.getParents(oldest);
-    return { base: parents[0] ?? EMPTY_TREE_HASH, newest };
   }
 
   private async _sortHashesOldestFirst(hashes: string[]): Promise<string[]> {

--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -16,6 +16,8 @@ import { parseDiff, buildMonacoContents, detectLanguage } from './DiffParser';
 import { getVscodeRepository } from './VscodeGitApi';
 import { ForcePushMode, Status, RefType } from './git.d';
 
+const EMPTY_TREE_HASH = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
 const STATUS_MAP: Record<string, GitFileStatus> = {
   M: 'modified', A: 'added', D: 'deleted',
   R: 'renamed', C: 'copied', U: 'conflicted',
@@ -739,15 +741,23 @@ export class GitService {
     } catch { return ''; }
   }
 
-  async getCombinedFiles(hashes: string[]): Promise<Array<{ path: string; status: string; added?: number; removed?: number }>> {
+  async getCombinedFiles(hashes: string[]): Promise<Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }>> {
+    const refs = await this._getInclusiveDiffRefs(hashes);
+    return refs ? this._getFilesBetweenRefs(refs.base, refs.newest) : [];
+  }
+
+  async getFilesBetween(hashes: string[]): Promise<Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }>> {
     const ordered = await this._sortHashesOldestFirst(hashes);
     const oldest = ordered[0];
     const newest = ordered[ordered.length - 1];
-    if (!oldest || !newest) return [];
+    return oldest && newest ? this._getFilesBetweenRefs(oldest, newest) : [];
+  }
+
+  private async _getFilesBetweenRefs(base: string, newest: string): Promise<Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }>> {
     try {
       const [nameStatus, numStat] = await Promise.all([
-        this.git.raw(['diff', '--name-status', `${oldest}~1`, newest]),
-        this.git.raw(['diff', '--numstat', `${oldest}~1`, newest]),
+        this.git.raw(['diff', '--name-status', base, newest]),
+        this.git.raw(['diff', '--numstat', base, newest]),
       ]);
       const stats = new Map<string, { added: number; removed: number }>();
       for (const line of numStat.trim().split('\n')) {
@@ -759,36 +769,35 @@ export class GitService {
         const p = parts[parts.length - 1];
         if (!isNaN(added) && !isNaN(removed)) stats.set(p, { added, removed });
       }
-      const files: Array<{ path: string; status: string; added?: number; removed?: number }> = [];
+      const files: Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }> = [];
       for (const line of nameStatus.trim().split('\n')) {
         if (!line.trim()) continue;
         const parts = line.split('\t');
         if (parts.length < 2) continue;
         const statusCode = parts[0][0];
         const filePath = parts[parts.length - 1];
+        const oldPath = (statusCode === 'R' || statusCode === 'C') && parts.length >= 3 ? parts[1] : undefined;
         const s = stats.get(filePath);
-        files.push({ status: statusCode, path: filePath, added: s?.added, removed: s?.removed });
+        files.push({ status: statusCode, path: filePath, added: s?.added, removed: s?.removed, ...(oldPath ? { oldPath } : {}) });
       }
       return files;
     } catch { return []; }
   }
 
   async getCombinedFileDiff(repoId: string, hashes: string[], filePath: string): Promise<FileDiff | null> {
-    const ordered = await this._sortHashesOldestFirst(hashes);
-    const oldest = ordered[0];
-    const newest = ordered[ordered.length - 1];
-    if (!oldest || !newest) return null;
+    const refs = await this._getInclusiveDiffRefs(hashes);
+    if (!refs) return null;
     try {
       const vsRepo = this.vsRepo();
-      const rawDiff = await this.git.raw(['diff', `${oldest}~1`, newest, '--', filePath, '--no-renames']);
+      const rawDiff = await this.git.raw(['diff', refs.base, refs.newest, '--', filePath, '--no-renames']);
       const diffs = parseDiff(rawDiff || `diff --git a/${filePath} b/${filePath}\n`, repoId);
       const diff = diffs[0] ?? { repoId, oldPath: filePath, newPath: filePath, isBinary: false, isNew: false, isDeleted: false, hunks: [] };
       if (vsRepo) {
-        diff.originalContent = await vsRepo.show(`${oldest}~1`, filePath).catch(() => '');
-        diff.modifiedContent = await vsRepo.show(newest, filePath).catch(() => '');
+        diff.originalContent = refs.base === EMPTY_TREE_HASH ? '' : await vsRepo.show(refs.base, filePath).catch(() => '');
+        diff.modifiedContent = await vsRepo.show(refs.newest, filePath).catch(() => '');
       } else {
-        diff.originalContent = await this.git.raw(['show', `${oldest}~1:${filePath}`]).catch(() => '');
-        diff.modifiedContent = await this.git.raw(['show', `${newest}:${filePath}`]).catch(() => '');
+        diff.originalContent = refs.base === EMPTY_TREE_HASH ? '' : await this.git.raw(['show', `${refs.base}:${filePath}`]).catch(() => '');
+        diff.modifiedContent = await this.git.raw(['show', `${refs.newest}:${filePath}`]).catch(() => '');
       }
       return diff;
     } catch { return null; }
@@ -816,6 +825,15 @@ export class GitService {
       if (p) files.push({ status: 'A', path: p });
     }
     return files;
+  }
+
+  private async _getInclusiveDiffRefs(hashes: string[]): Promise<{ base: string; newest: string } | null> {
+    const ordered = await this._sortHashesOldestFirst(hashes);
+    const oldest = ordered[0];
+    const newest = ordered[ordered.length - 1];
+    if (!oldest || !newest) return null;
+    const parents = await this.getParents(oldest);
+    return { base: parents[0] ?? EMPTY_TREE_HASH, newest };
   }
 
   private async _sortHashesOldestFirst(hashes: string[]): Promise<string[]> {

--- a/src/host/panels/CombinedDiffPanel.ts
+++ b/src/host/panels/CombinedDiffPanel.ts
@@ -4,6 +4,42 @@ import type { WorkspaceGitManager } from '../git/WorkspaceGitManager';
 import { showGitError } from '../utils/gitErrorUtils';
 import { logWarn } from '../utils/Logger';
 
+const EMPTY_TREE = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+function gitUri(rootPath: string, ref: string, filePath: string): vscode.Uri {
+  const fileUri = vscode.Uri.file(path.join(rootPath, filePath));
+  return vscode.Uri.from({ scheme: 'git', path: fileUri.path, query: JSON.stringify({ path: fileUri.fsPath, ref }) });
+}
+
+export async function openRangeFileDiff(
+  manager: WorkspaceGitManager,
+  repoId: string,
+  hashes: string[],
+  filePath: string,
+  status?: string,
+  oldPath?: string,
+): Promise<void> {
+  const repo = manager.getRepo(repoId);
+  if (!repo) {
+    vscode.window.showErrorMessage('Repository not found.');
+    return;
+  }
+
+  try {
+    const ordered = await repo.getCombinedFilesOrder(hashes);
+    const oldest = ordered[0];
+    const newest = ordered[ordered.length - 1];
+    if (!oldest || !newest) return;
+    const originalPath = oldPath ?? filePath;
+    const original = gitUri(repo.rootPath, status === 'A' ? EMPTY_TREE : oldest, originalPath);
+    const modified = gitUri(repo.rootPath, status === 'D' ? EMPTY_TREE : newest, filePath);
+    const title = `${path.basename(filePath)} (${oldest.slice(0, 7)}…${newest.slice(0, 7)})`;
+    await vscode.commands.executeCommand('vscode.diff', original, modified, title);
+  } catch (e: unknown) {
+    showGitError('rangeDiff', e);
+  }
+}
+
 export async function openCombinedDiffPanel(
   extensionUri: vscode.Uri,
   manager: WorkspaceGitManager,
@@ -22,7 +58,7 @@ export async function openCombinedDiffPanel(
     return;
   }
 
-  let files: Array<{ path: string; status: string; added?: number; removed?: number }> = [];
+  let files: Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }> = [];
   let commitMetas: Array<{ hash: string; shortHash: string; message: string; authorName: string; authorDate: string }> = [];
   let orderedHashes: string[] = [];
 
@@ -51,20 +87,16 @@ export async function openCombinedDiffPanel(
 
   const oldest = commitMetas[0];
   const newest = commitMetas[commitMetas.length - 1];
-  const EMPTY_TREE = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
   const rootPath = repo.rootPath;
-
-  const gitUri = (ref: string, filePath: string): vscode.Uri => {
-    const fileUri = vscode.Uri.file(path.join(rootPath, filePath));
-    return vscode.Uri.from({ scheme: 'git', path: fileUri.path, query: JSON.stringify({ path: fileUri.fsPath, ref }) });
-  };
+  const parents = await repo.getParents(oldest.hash);
+  const base = parents[0] ?? EMPTY_TREE;
 
   const resources = files
     .filter(f => f.status !== 'U')
     .map(f => {
       const label = vscode.Uri.file(path.join(rootPath, f.path));
-      const original = gitUri(f.status === 'A' ? EMPTY_TREE : `${oldest.hash}~1`, f.path);
-      const modified = gitUri(f.status === 'D' ? EMPTY_TREE : newest.hash, f.path);
+      const original = gitUri(rootPath, f.status === 'A' ? EMPTY_TREE : base, f.oldPath ?? f.path);
+      const modified = gitUri(rootPath, f.status === 'D' ? EMPTY_TREE : newest.hash, f.path);
       return [label, original, modified] as [vscode.Uri, vscode.Uri, vscode.Uri];
     });
 

--- a/src/host/panels/CombinedDiffPanel.ts
+++ b/src/host/panels/CombinedDiffPanel.ts
@@ -58,7 +58,7 @@ export async function openCombinedDiffPanel(
     return;
   }
 
-  let files: Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }> = [];
+  let files: Array<{ path: string; status: string; added?: number; removed?: number }> = [];
   let commitMetas: Array<{ hash: string; shortHash: string; message: string; authorName: string; authorDate: string }> = [];
   let orderedHashes: string[] = [];
 
@@ -88,14 +88,12 @@ export async function openCombinedDiffPanel(
   const oldest = commitMetas[0];
   const newest = commitMetas[commitMetas.length - 1];
   const rootPath = repo.rootPath;
-  const parents = await repo.getParents(oldest.hash);
-  const base = parents[0] ?? EMPTY_TREE;
 
   const resources = files
     .filter(f => f.status !== 'U')
     .map(f => {
       const label = vscode.Uri.file(path.join(rootPath, f.path));
-      const original = gitUri(rootPath, f.status === 'A' ? EMPTY_TREE : base, f.oldPath ?? f.path);
+      const original = gitUri(rootPath, f.status === 'A' ? EMPTY_TREE : `${oldest.hash}~1`, f.path);
       const modified = gitUri(rootPath, f.status === 'D' ? EMPTY_TREE : newest.hash, f.path);
       return [label, original, modified] as [vscode.Uri, vscode.Uri, vscode.Uri];
     });

--- a/src/host/panels/GitLogPanelProvider.ts
+++ b/src/host/panels/GitLogPanelProvider.ts
@@ -399,6 +399,22 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
         break;
       }
 
+      case 'LOG_REQUEST_RANGE_FILES': {
+        const repo = this.manager.getRepo(msg.repoId);
+        if (!repo) { this.post({ type: 'LOG_RANGE_FILES_RESULT', requestId: msg.requestId, files: [], orderedHashes: [], error: 'Repo not found' }); return; }
+        try {
+          const [files, orderedHashes] = await Promise.all([
+            repo.getFilesBetween(msg.hashes),
+            repo.getCombinedFilesOrder(msg.hashes),
+          ]);
+          this.post({ type: 'LOG_RANGE_FILES_RESULT', requestId: msg.requestId, files, orderedHashes });
+        } catch (e: unknown) {
+          logError('rangeFiles', formatGitError(e), getRawErrorDetail(e));
+          this.post({ type: 'LOG_RANGE_FILES_RESULT', requestId: msg.requestId, files: [], orderedHashes: [], error: formatGitError(e) });
+        }
+        break;
+      }
+
       case 'LOG_REQUEST_MERGE_COMMITS': {
         const repo = this.manager.getRepo(msg.repoId);
         if (!repo) { this.post({ type: 'LOG_MERGE_COMMITS_RESULT', requestId: msg.requestId, commits: [], error: 'Repo not found' }); return; }
@@ -433,6 +449,12 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
         } catch (e: unknown) {
           showGitError('openDiff', e);
         }
+        break;
+      }
+
+      case 'LOG_OPEN_RANGE_FILE_DIFF': {
+        const { openRangeFileDiff } = await import('./CombinedDiffPanel');
+        await openRangeFileDiff(this.manager, msg.repoId, msg.hashes, msg.filePath, msg.fileStatus, msg.oldPath);
         break;
       }
 

--- a/src/host/types/messages.ts
+++ b/src/host/types/messages.ts
@@ -212,6 +212,7 @@ export type HostToLogMsg =
   | { type: 'LOG_COMMITS_BATCH'; commits: CommitNode[]; isLast: boolean; batchIndex: number; requestId?: string }
   | { type: 'LOG_DIFF_RESULT'; requestId: string; files: Array<{ path: string; status: string }>; diff: FileDiff | null; error?: string }
   | { type: 'LOG_COMMIT_FILES'; requestId: string; files: Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }>; error?: string }
+  | { type: 'LOG_RANGE_FILES_RESULT'; requestId: string; files: Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }>; orderedHashes: string[]; error?: string }
   | { type: 'LOG_BRANCH_OP_RESULT'; requestId: string; ok: boolean; output?: string; error?: string }
   | { type: 'LOG_REFS_UPDATE'; repoId: string; branches: BranchInfo[] }
   | { type: 'LOG_TAGS_UPDATE'; repoId: string; tags: TagInfo[] }
@@ -233,8 +234,10 @@ export type HostToLogMsg =
 export type LogToHostMsg =
   | { type: 'LOG_REQUEST_COMMITS'; repoIds: string[]; limit: number; skip: number; requestId?: string; filterText?: string; filterAuthor?: string; filterBranch?: string; filterDateFrom?: string; filterDateTo?: string }
   | { type: 'LOG_REQUEST_COMMIT_FILES'; requestId: string; repoId: string; hash: string; parents?: string[] }
+  | { type: 'LOG_REQUEST_RANGE_FILES'; requestId: string; repoId: string; hashes: string[] }
   | { type: 'LOG_REQUEST_FILE_DIFF'; requestId: string; repoId: string; hash: string; filePath: string }
   | { type: 'LOG_OPEN_FILE_DIFF'; repoId: string; hash: string; filePath: string; fileStatus?: string; oldPath?: string; parents?: string[]; combined?: boolean }
+  | { type: 'LOG_OPEN_RANGE_FILE_DIFF'; repoId: string; hashes: string[]; filePath: string; fileStatus?: string; oldPath?: string }
   | { type: 'LOG_OPEN_FILE'; repoId: string; filePath: string }
   | { type: 'LOG_REVERT_FILE'; requestId: string; repoId: string; hash: string; filePath: string; fileStatus?: string }
   | { type: 'LOG_CHERRY_PICK_FILE'; requestId: string; repoId: string; hash: string; filePath: string; oldPath?: string }

--- a/src/webview/gitLog/components/CommitDetail.tsx
+++ b/src/webview/gitLog/components/CommitDetail.tsx
@@ -128,6 +128,7 @@ function FileContextMenu({ x, y, onShowDiff, onShowCombinedDiff, onEditSource, o
 
 interface Props {
   commit: CommitNode | null;
+  range?: { older: CommitNode; newer: CommitNode };
   files: Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }>;
   selectedFile: { path: string; status: string } | null;
   loadingFiles: boolean;
@@ -342,7 +343,7 @@ function RefBadgeIcon({ group }: { group: RefGroup }) {
 
 /* ─── Main component ──────────────────────────────────────────────────────── */
 
-export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoColor, repos, iconTheme, onSelectFile, onClose, refColors }: Props) {
+export function CommitDetail({ commit, range, files, selectedFile, loadingFiles, repoColor, repos, iconTheme, onSelectFile, onClose, refColors }: Props) {
   const [viewMode, setViewMode] = useState<'tree' | 'flat'>('tree');
   const [allExpanded, setAllExpanded] = useState<boolean | null>(null);
   const [mergeCommits, setMergeCommits] = useState<MergeParentCommit[]>([]);
@@ -357,11 +358,12 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
   const [refsExpanded, setRefsExpanded] = useState(false);
 
   const repoName = useMemo(() => {
-    if (!commit) return null;
-    return repos.find(r => r.id === commit.repoId)?.name ?? null;
-  }, [commit, repos]);
+    const activeCommit = range?.newer ?? commit;
+    if (!activeCommit) return null;
+    return repos.find(r => r.id === activeCommit.repoId)?.name ?? null;
+  }, [commit, range, repos]);
 
-  const isMerge = (commit?.parents.length ?? 0) >= 2;
+  const isMerge = !range && (commit?.parents.length ?? 0) >= 2;
 
   useEffect(() => {
     const handler = (event: MessageEvent<HostToLogMsg>) => {
@@ -378,7 +380,7 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
   }, []);
 
   useEffect(() => {
-    if (!commit || commit.isStash) { setContainingBranches({ local: [], remote: [], tags: [] }); setLoadingBranches(false); return; }
+    if (range || !commit || commit.isStash) { setContainingBranches({ local: [], remote: [], tags: [] }); setLoadingBranches(false); return; }
     setRefsExpanded(false);
     setLoadingBranches(true);
     const reqId = generateId();
@@ -394,12 +396,12 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
       repoId: commit.repoId,
       hash: commit.hash,
     } satisfies LogToHostMsg);
-  }, [commit?.hash]);
+  }, [commit?.hash, range]);
 
   useEffect(() => {
     setSelectedMergeHash(null);
     setMergeFiles([]);
-    if (!commit || !isMerge || commit.isStash) { setMergeCommits([]); return; }
+    if (range || !commit || !isMerge || commit.isStash) { setMergeCommits([]); return; }
     setLoadingMerge(true);
     const reqId = generateId();
     pendingRef.current.set(reqId, (msg) => {
@@ -415,10 +417,21 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
       hash: commit.hash,
       parents: commit.parents,
     } satisfies LogToHostMsg);
-  }, [commit?.hash]);
+  }, [commit?.hash, range]);
 
   function openVscodeDiff(file: FileEntry, hash?: string, combined?: boolean) {
     onSelectFile(file);
+    if (range) {
+      getVsCodeApi().postMessage({
+        type: 'LOG_OPEN_RANGE_FILE_DIFF',
+        repoId: range.newer.repoId,
+        hashes: [range.older.hash, range.newer.hash],
+        filePath: file.path,
+        fileStatus: file.status,
+        oldPath: file.oldPath,
+      } satisfies LogToHostMsg);
+      return;
+    }
     if (!commit) return;
     getVsCodeApi().postMessage({
       type: 'LOG_OPEN_FILE_DIFF',
@@ -539,9 +552,9 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
     );
   }
 
-  const activeFiles = selectedMergeHash ? mergeFiles : files;
-  const activeLoading = selectedMergeHash ? loadingMergeFiles : loadingFiles;
-  const activeHash = selectedMergeHash ?? commit?.hash;
+  const activeFiles = !range && selectedMergeHash ? mergeFiles : files;
+  const activeLoading = !range && selectedMergeHash ? loadingMergeFiles : loadingFiles;
+  const activeHash = !range && selectedMergeHash ? selectedMergeHash : commit?.hash;
 
   const tree = viewMode === 'tree' && activeFiles.length > 0
     ? buildTree(activeFiles)
@@ -550,22 +563,26 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
   return (
     <div style={styles.container} onContextMenu={e => e.preventDefault()}>
       <div style={styles.topActions}>
-        <button
-          data-top-action-btn=""
-          style={styles.topActionBtn}
-          title="Open Changes"
-          onClick={() => getVsCodeApi().postMessage({ type: 'LOG_OPEN_COMMIT_CHANGES', repoId: commit.repoId, hash: commit.hash } satisfies LogToHostMsg)}
-        >
-          <Codicon name="diff-multiple" style={{ fontSize: '16px' }} />
-        </button>
-        <button
-          data-top-action-btn=""
-          style={styles.topActionBtn}
-          title="Open extended commit detail"
-          onClick={() => getVsCodeApi().postMessage({ type: 'LOG_OPEN_EXTENDED_DETAIL', repoId: commit.repoId, hash: commit.hash } satisfies LogToHostMsg)}
-        >
-          <Codicon name="open-preview" style={{ fontSize: '16px' }} />
-        </button>
+        {!range && (
+          <>
+            <button
+              data-top-action-btn=""
+              style={styles.topActionBtn}
+              title="Open Changes"
+              onClick={() => getVsCodeApi().postMessage({ type: 'LOG_OPEN_COMMIT_CHANGES', repoId: commit.repoId, hash: commit.hash } satisfies LogToHostMsg)}
+            >
+              <Codicon name="diff-multiple" style={{ fontSize: '16px' }} />
+            </button>
+            <button
+              data-top-action-btn=""
+              style={styles.topActionBtn}
+              title="Open extended commit detail"
+              onClick={() => getVsCodeApi().postMessage({ type: 'LOG_OPEN_EXTENDED_DETAIL', repoId: commit.repoId, hash: commit.hash } satisfies LogToHostMsg)}
+            >
+              <Codicon name="open-preview" style={{ fontSize: '16px' }} />
+            </button>
+          </>
+        )}
         {onClose && (
           <button data-top-action-btn="" style={styles.topActionBtn} title="Close commit detail" onClick={onClose}>
             <Codicon name="layout-sidebar-right" style={{ fontSize: '16px' }} />
@@ -574,8 +591,29 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
       </div>
       {/* Commit header */}
       <div style={styles.header}>
-        {repoName && (
-          <div style={styles.repoRow}>
+        {range ? (
+          <>
+            {repoName && (
+              <div style={styles.repoRow}>
+                <Codicon name="repo" style={styles.repoIcon} />
+                <span style={styles.repoName(repoColor)}>{repoName}</span>
+              </div>
+            )}
+            <div style={styles.rangeTitle}>
+              <Codicon name="diff-multiple" style={{ fontSize: '14px', opacity: 0.8 }} />
+              <span>Compare commits</span>
+            </div>
+            <div style={styles.hashRow}>
+              <span style={styles.hash}>{range.older.shortHash}</span>
+              <Codicon name="arrow-right" style={{ fontSize: '11px', opacity: 0.6 }} />
+              <span style={styles.hash}>{range.newer.shortHash}</span>
+            </div>
+            <div style={styles.rangeHint}>Changes between the selected snapshots</div>
+          </>
+        ) : (
+          <>
+            {repoName && (
+              <div style={styles.repoRow}>
             <Codicon name="repo" style={styles.repoIcon} />
             <span style={styles.repoName(repoColor)}>{repoName}</span>
           </div>
@@ -760,8 +798,8 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
         })()}
 
         {/* Merged commits section */}
-        {isMerge && (
-          <div style={styles.mergeSection}>
+            {isMerge && (
+              <div style={styles.mergeSection}>
             <div style={styles.mergeSectionTitle}>
               <Codicon name="git-merge" style={{ fontSize: '11px', opacity: 0.7 }} />
               <span>Merged commits</span>
@@ -815,7 +853,9 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
                 </div>
               );
             })}
-          </div>
+              </div>
+            )}
+          </>
         )}
       </div>
 
@@ -863,7 +903,7 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
       </div>
 
       {/* File context menu */}
-      {ctxMenu && commit && (
+      {ctxMenu && commit && !range && (
         <FileContextMenu
           x={ctxMenu.x}
           y={ctxMenu.y}
@@ -905,7 +945,7 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
                 selectedFile={selectedFile}
                 ctxFile={ctxMenu?.file.path ?? null}
                 onOpen={f => openVscodeDiff(f, activeHash)}
-                onContextMenu={(e, f) => setCtxMenu({ x: e.clientX, y: e.clientY, file: f })}
+                onContextMenu={(e, f) => { if (!range) setCtxMenu({ x: e.clientX, y: e.clientY, file: f }); }}
                 allExpanded={allExpanded}
                 iconTheme={iconTheme}
               />
@@ -926,7 +966,7 @@ export function CommitDetail({ commit, files, selectedFile, loadingFiles, repoCo
               iconTheme={iconTheme}
               activeHash={activeHash}
               onOpen={openVscodeDiff}
-              onContextMenu={setCtxMenu}
+              onContextMenu={range ? () => {} : setCtxMenu}
             />
           );
         })}
@@ -1001,6 +1041,18 @@ const styles = {
     textTransform: 'uppercase' as const,
     letterSpacing: '0.04em',
   }),
+  rangeTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    fontSize: '13px',
+    fontWeight: 600,
+    paddingRight: '28px',
+  } as React.CSSProperties,
+  rangeHint: {
+    fontSize: '11px',
+    opacity: 0.65,
+  } as React.CSSProperties,
   hashRow: {
     display: 'flex',
     alignItems: 'center',

--- a/src/webview/gitLog/components/CommitList.tsx
+++ b/src/webview/gitLog/components/CommitList.tsx
@@ -23,6 +23,7 @@ interface Props {
   currentBranchByRepo: Record<string, string>;
   headHashByRepo: Record<string, string>;
   onSelect: (commit: LaidOutCommit) => void;
+  onMultiSelectionChange?: (commits: LaidOutCommit[]) => void;
   onLoadMore: () => void;
   hasMore: boolean;
   storeHasMore: boolean;
@@ -80,7 +81,7 @@ function CommitSkeleton() {
 
 const SKELETON_MIN_MS = 400;
 
-export function CommitList({ layout, selectedHash, repoColors, repos, activeRepoId, currentBranchByRepo, headHashByRepo, onSelect, onLoadMore, hasMore, storeHasMore, loading, backgroundLoading, scrollToHash, onScrolledToHash, aiEnabled }: Props) {
+export function CommitList({ layout, selectedHash, repoColors, repos, activeRepoId, currentBranchByRepo, headHashByRepo, onSelect, onMultiSelectionChange, onLoadMore, hasMore, storeHasMore, loading, backgroundLoading, scrollToHash, onScrolledToHash, aiEnabled }: Props) {
   const { commits, segments, refColors } = layout;
 
   // graphWidth is stable: it only grows, never shrinks, so adding new commits
@@ -136,6 +137,12 @@ export function CommitList({ layout, selectedHash, repoColors, repos, activeRepo
   const popoverHoveredRef = useRef(false);
   const closePopoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [multiSelectHashes, setMultiSelectHashes] = useState<Set<string>>(new Set());
+  const multiSelectedCommits = useMemo(
+    () => commits.filter(c => multiSelectHashes.has(`${c.hash}:${c.repoId}`)),
+    [commits, multiSelectHashes],
+  );
+  useEffect(() => onMultiSelectionChange?.(multiSelectedCommits), [multiSelectedCommits, onMultiSelectionChange]);
+
   const [containerWidth, setContainerWidth] = useState<number>(9999);
   const containerRoRef = useRef<ResizeObserver | null>(null);
 

--- a/src/webview/gitLog/main.tsx
+++ b/src/webview/gitLog/main.tsx
@@ -12,6 +12,7 @@ import { useResize } from '../shared/useResize';
 import { Codicon } from '../shared/Codicon';
 import { getVsCodeApi } from '../shared/vscodeApi';
 import type { LogToHostMsg, HostToLogMsg } from '../../host/types/messages';
+import type { CommitNode } from '../shared/types';
 
 function generateId() {
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
@@ -28,6 +29,11 @@ function App() {
   const [detailCollapsed, setDetailCollapsed] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [themeVersion, setThemeVersion] = useState(0);
+  const [multiSelectedCommits, setMultiSelectedCommits] = useState<CommitNode[]>([]);
+  const [rangeEndpoints, setRangeEndpoints] = useState<{ older: CommitNode; newer: CommitNode } | null>(null);
+  const [rangeFiles, setRangeFiles] = useState<Array<{ path: string; status: string; added?: number; removed?: number; oldPath?: string }>>([]);
+  const [loadingRangeFiles, setLoadingRangeFiles] = useState(false);
+  const rangeRequestKeyRef = useRef('');
 
   useEffect(() => {
     const obs = new MutationObserver(() => setThemeVersion(v => v + 1));
@@ -53,6 +59,47 @@ function App() {
       pendingRef.current.set(reqId, r => resolve(r as T));
       getVsCodeApi().postMessage(m);
     });
+  }, []);
+
+  const selectedRangeKey = multiSelectedCommits.length === 2
+    ? `${multiSelectedCommits[0].repoId}:${multiSelectedCommits.map(c => c.hash).sort().join(':')}`
+    : '';
+  rangeRequestKeyRef.current = selectedRangeKey;
+
+  useEffect(() => {
+    if (!selectedRangeKey || multiSelectedCommits.length !== 2) {
+      setRangeEndpoints(null);
+      setRangeFiles([]);
+      setLoadingRangeFiles(false);
+      return;
+    }
+
+    const selectedByHash = new Map(multiSelectedCommits.map(c => [c.hash, c]));
+    const fallback = [...multiSelectedCommits].sort(
+      (a, b) => new Date(a.committerDate).getTime() - new Date(b.committerDate).getTime(),
+    );
+    setRangeEndpoints({ older: fallback[0], newer: fallback[1] });
+    setRangeFiles([]);
+    setLoadingRangeFiles(true);
+    useLogStore.getState().selectFile(null);
+
+    request<Extract<HostToLogMsg, { type: 'LOG_RANGE_FILES_RESULT' }>>({
+      type: 'LOG_REQUEST_RANGE_FILES',
+      requestId: '',
+      repoId: multiSelectedCommits[0].repoId,
+      hashes: multiSelectedCommits.map(c => c.hash),
+    }).then(msg => {
+      if (rangeRequestKeyRef.current !== selectedRangeKey) return;
+      const ordered = msg.orderedHashes.map(hash => selectedByHash.get(hash)).filter((c): c is CommitNode => !!c);
+      if (ordered.length === 2) setRangeEndpoints({ older: ordered[0], newer: ordered[1] });
+      setRangeFiles(msg.files);
+      setLoadingRangeFiles(false);
+    });
+  }, [selectedRangeKey, request]);
+
+  const handleMultiSelectionChange = useCallback((commits: CommitNode[]) => {
+    setMultiSelectedCommits(commits);
+    if (commits.length === 2) setDetailCollapsed(false);
   }, []);
 
   useEffect(() => {
@@ -267,9 +314,11 @@ function App() {
     return map;
   }, [store.branches]);
 
-  const selectedRepoColor = store.selectedCommit
-    ? repoColors[store.selectedCommit.repoId]
-    : undefined;
+  const selectedRepoColor = rangeEndpoints
+    ? repoColors[rangeEndpoints.newer.repoId]
+    : store.selectedCommit
+      ? repoColors[store.selectedCommit.repoId]
+      : undefined;
 
   // text/author are debounced inside DebouncedInput; branch/date/repo fire immediately
   const handleFilterChange = useCallback((key: keyof import('./store/logStore').CommitFilters, value: string) => {
@@ -313,7 +362,7 @@ function App() {
     [store.tags, activeRepoId]
   );
 
-  const hasSelectedCommit = !!store.selectedCommit;
+  const hasSelectedCommit = !!store.selectedCommit || !!rangeEndpoints;
 
   const showNoRepo = store.repos.length === 0 && store.initialized;
   const noRepoOverlay = showNoRepo ? (
@@ -440,6 +489,7 @@ function App() {
             currentBranchByRepo={currentBranchByRepo}
             headHashByRepo={headHashByRepo}
             onSelect={(commit) => { store.selectCommit(commit); setDetailCollapsed(false); }}
+            onMultiSelectionChange={handleMultiSelectionChange}
             onLoadMore={handleLoadMore}
             hasMore={store.hasMore}
             storeHasMore={store.hasMore}
@@ -458,10 +508,11 @@ function App() {
         {hasSelectedCommit && !detailCollapsed && (
           <div ref={detailRef} style={detailPane}>
             <CommitDetail
-              commit={store.selectedCommit}
-              files={store.commitFiles}
+              commit={rangeEndpoints?.newer ?? store.selectedCommit}
+              range={rangeEndpoints ?? undefined}
+              files={rangeEndpoints ? rangeFiles : store.commitFiles}
               selectedFile={store.selectedFile}
-              loadingFiles={store.loadingFiles}
+              loadingFiles={rangeEndpoints ? loadingRangeFiles : store.loadingFiles}
               repoColor={selectedRepoColor}
               repos={store.repos}
               iconTheme={store.iconTheme}


### PR DESCRIPTION
## Problem

Selecting two commits in the Git Log did not show their snapshot differences in the detail panel. Reviewing the comparison required opening a separate combined-diff view, whose inclusive semantics also include changes introduced by the oldest selected commit.

## Summary

- Show a commit comparison in the Git Log detail panel when exactly two commits are selected
- Compare the selected snapshots directly from the oldest commit to the newest commit
- Exclude changes introduced by the oldest selected commit
- Display changed files using the existing tree and flat views
- Open the corresponding snapshot diff when a changed file is selected
- Support renamed files and commits from unrelated branches
- Restore normal commit details when the selection returns to one commit
- Leave the explicit **View Combined Diff** action unchanged and inclusive
- Update the panel wording to distinguish snapshot comparison from combined changes

<img height="500" alt="image" src="https://github.com/user-attachments/assets/2b536be8-e870-41c6-b737-59c5054c7c8e" />

## Validation

- Host and webview TypeScript validation
- Production build
- Focused strict TypeScript validation for the changed diff panel
- `git diff --check`