### PR TITLE
Focus branch head by clicking its name in branch list

### DIFF
--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -387,6 +387,20 @@ export class GitService {
   }
 
   async getBranches(): Promise<BranchInfo[]> {
+    const tipMetadata = new Map<string, { hash: string; date?: string }>();
+    try {
+      const raw = await this.git.raw([
+        'for-each-ref',
+        '--format=%(objectname)%00%(committerdate:iso-strict)%00%(refname:short)',
+        'refs/heads/',
+        'refs/remotes/',
+      ]);
+      for (const line of raw.trim().split('\n')) {
+        const [hash, date, name] = line.split('\0');
+        if (hash && name) tipMetadata.set(name, { hash, date: date || undefined });
+      }
+    } catch { /* branch refs still come from the primary provider */ }
+
     const vsRepo = this.vsRepo();
     if (vsRepo) {
       // getBranches({ remote: false }) returns local branches (RefType.Head),
@@ -409,7 +423,8 @@ export class GitService {
           fullName: `refs/heads/${name}`,
           isHead,
           isRemote: false,
-          lastCommitHash: ref.commit,
+          lastCommitHash: ref.commit ?? tipMetadata.get(name)?.hash,
+          lastCommitDate: tipMetadata.get(name)?.date,
           aheadBehind: (isHead && head!.ahead !== undefined && head!.behind !== undefined)
             ? { ahead: head!.ahead, behind: head!.behind }
             : undefined,
@@ -429,7 +444,8 @@ export class GitService {
           isHead: false,
           isRemote: true,
           remoteName,
-          lastCommitHash: ref.commit,
+          lastCommitHash: ref.commit ?? tipMetadata.get(name)?.hash,
+          lastCommitDate: tipMetadata.get(name)?.date,
         });
       }
 
@@ -437,15 +453,6 @@ export class GitService {
     }
 
     // Fallback: simple-git
-    // Fetch full hashes for all branches separately (simple-git returns short hashes)
-    const fullHashMap = new Map<string, string>();
-    try {
-      const forEachRefRaw = await this.git.raw(['for-each-ref', '--format=%(objectname) %(refname:short)', 'refs/heads/', 'refs/remotes/']);
-      for (const line of forEachRefRaw.trim().split('\n')) {
-        const [hash, name] = line.trim().split(' ');
-        if (hash && name) fullHashMap.set(name, hash);
-      }
-    } catch { /* ignore, fall back to short hashes */ }
     const result = await this.git.branch(['-avv', '--sort=-committerdate']);
     const branches: BranchInfo[] = [];
     for (const [name, branch] of Object.entries(result.branches)) {
@@ -468,7 +475,8 @@ export class GitService {
         isHead: branch.current,
         isRemote,
         remoteName,
-        lastCommitHash: fullHashMap.get(cleanName) ?? branch.commit,
+        lastCommitHash: tipMetadata.get(cleanName)?.hash ?? branch.commit,
+        lastCommitDate: tipMetadata.get(cleanName)?.date,
         aheadBehind,
       });
     }

--- a/src/host/git/WorkspaceGitManager.ts
+++ b/src/host/git/WorkspaceGitManager.ts
@@ -830,15 +830,19 @@ export class WorkspaceGitManager implements vscode.Disposable {
       }
     }
 
+    const isInterleaved = targets.length > 1;
+    const fetchLimit = isInterleaved ? limit + skip : limit;
+    const fetchSkip = isInterleaved ? 0 : skip;
     const results = await Promise.allSettled(
-      targets.map(r => r.getLog(limit, skip, { ...opts, worktreeServices: worktreesByMainRepo.get(r.rootPath) ?? [] }))
+      targets.map(r => r.getLog(fetchLimit, fetchSkip, { ...opts, worktreeServices: worktreesByMainRepo.get(r.rootPath) ?? [] }))
     );
     const allCommits = results
       .filter((r): r is PromiseFulfilledResult<CommitNode[]> => r.status === 'fulfilled')
       .flatMap(r => r.value);
 
     allCommits.sort((a, b) => new Date(b.committerDate).getTime() - new Date(a.committerDate).getTime());
-    return allCommits.slice(0, limit);
+    const pageStart = isInterleaved ? skip : 0;
+    return allCommits.slice(pageStart, pageStart + limit);
   }
 
   async fetchAll(): Promise<void> {

--- a/src/webview/gitLog/components/BranchSidebar.tsx
+++ b/src/webview/gitLog/components/BranchSidebar.tsx
@@ -11,8 +11,10 @@ interface Props {
   tags: TagInfo[];
   filter: string;
   selectedBranchFilter: string;
+  activeRepoId?: string | null;
   onFilterChange: (v: string) => void;
   onBranchFilterSelect: (branchName: string) => void;
+  onBranchFocus: (branch: BranchInfo) => void;
   onCheckout: (repoIds: string[], branchName: string) => void;
   onMerge: (repoId: string, from: string) => void;
   onRebase: (repoId: string, onto: string) => void;
@@ -91,7 +93,7 @@ function buildMergedTags(tags: TagInfo[]): MergedTag[] {
 }
 
 export const BranchSidebar = forwardRef<HTMLDivElement, Props>(function BranchSidebar({
-  repos, branches, tags, filter, selectedBranchFilter, onFilterChange, onBranchFilterSelect,
+  repos, branches, tags, filter, selectedBranchFilter, activeRepoId, onFilterChange, onBranchFilterSelect, onBranchFocus,
   onCheckout, onMerge, onRebase, onDelete, onFetchRepo, onPull, onPush,
   onCheckoutTag, onMergeTag, onPushTag, onDeleteTag, onCollapse, hidden,
 }, ref) {
@@ -149,6 +151,21 @@ export const BranchSidebar = forwardRef<HTMLDivElement, Props>(function BranchSi
     return merged.instances.find(i => i.isHead) ?? merged.instances[0];
   }
 
+  function focusInstance(merged: MergedBranch): BranchInfo | undefined {
+    const candidates = merged.instances.filter(instance => !!instance.lastCommitHash);
+    const activeInstance = activeRepoId ? candidates.find(instance => instance.repoId === activeRepoId) : undefined;
+    if (activeInstance) return activeInstance;
+
+    const repoNames = new Map(repos.map(repo => [repo.id, repo.name]));
+    return [...candidates].sort((a, b) => {
+      const aTimestamp = Date.parse(a.lastCommitDate ?? '');
+      const bTimestamp = Date.parse(b.lastCommitDate ?? '');
+      const dateDifference = (Number.isNaN(bTimestamp) ? 0 : bTimestamp) - (Number.isNaN(aTimestamp) ? 0 : aTimestamp);
+      if (dateDifference !== 0) return dateDifference;
+      return (repoNames.get(a.repoId) ?? a.repoId).localeCompare(repoNames.get(b.repoId) ?? b.repoId);
+    })[0];
+  }
+
   return (
     <div ref={ref} style={hidden ? { ...styles.container, display: 'none' } : styles.container} onClick={() => { setContextMenu(null); setTagContextMenu(null); }}>
       {/* Sticky header: search + repo list */}
@@ -192,6 +209,10 @@ export const BranchSidebar = forwardRef<HTMLDivElement, Props>(function BranchSi
             e.stopPropagation();
             setContextMenu({ merged: m, x: e.clientX, y: e.clientY });
           }}
+          onClick={() => {
+            const instance = focusInstance(m);
+            if (instance) onBranchFocus(instance);
+          }}
           onDoubleClick={() => onBranchFilterSelect(m.baseName)}
         />
       ))}
@@ -219,6 +240,10 @@ export const BranchSidebar = forwardRef<HTMLDivElement, Props>(function BranchSi
                   e.preventDefault();
                   e.stopPropagation();
                   setContextMenu({ merged: m, x: e.clientX, y: e.clientY });
+                }}
+                onClick={() => {
+                  const instance = focusInstance(m);
+                  if (instance) onBranchFocus(instance);
                 }}
                 onDoubleClick={() => onBranchFilterSelect(m.baseName)}
               />
@@ -294,19 +319,25 @@ export const BranchSidebar = forwardRef<HTMLDivElement, Props>(function BranchSi
   );
 });
 
-function BranchRow({ merged, repoColorMap, multiRepo, isFilterSelected, isCtxActive, onContextMenu, onDoubleClick }: {
+function BranchRow({ merged, repoColorMap, multiRepo, isFilterSelected, isCtxActive, onContextMenu, onClick, onDoubleClick }: {
   merged: MergedBranch;
   repoColorMap: Record<string, string>;
   multiRepo: boolean;
   isFilterSelected: boolean;
   isCtxActive: boolean;
   onContextMenu: (e: React.MouseEvent) => void;
+  onClick: () => void;
   onDoubleClick: () => void;
 }) {
   const { baseName, isPrimary, isHead, repoIds } = merged;
   const isRemote = merged.instances[0].isRemote;
   const [hovered, setHovered] = useState(false);
   const primaryColor = primaryBranchColor();
+  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
+  }, []);
 
   return (
     <div
@@ -314,8 +345,21 @@ function BranchRow({ merged, repoColorMap, multiRepo, isFilterSelected, isCtxAct
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onContextMenu={onContextMenu}
-      onDoubleClick={onDoubleClick}
-      title={`${baseName}\nDouble-click to filter by this branch · Right-click for git actions`}
+      onClick={() => {
+        if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
+        clickTimerRef.current = setTimeout(() => {
+          clickTimerRef.current = null;
+          onClick();
+        }, 300);
+      }}
+      onDoubleClick={() => {
+        if (clickTimerRef.current) {
+          clearTimeout(clickTimerRef.current);
+          clickTimerRef.current = null;
+        }
+        onDoubleClick();
+      }}
+      title={`${baseName}\nClick to focus branch head · Double-click to filter · Right-click for git actions`}
     >
       <Codicon
         name={isPrimary ? 'git-branch' : isRemote ? 'cloud' : 'git-branch'}

--- a/src/webview/gitLog/components/CommitList.tsx
+++ b/src/webview/gitLog/components/CommitList.tsx
@@ -28,8 +28,8 @@ interface Props {
   storeHasMore: boolean;
   loading: boolean;
   backgroundLoading?: boolean;
-  scrollToHash?: string | null;
-  onScrolledToHash?: () => void;
+  scrollTarget?: { hash: string; repoId: string } | null;
+  onScrollTargetHandled?: () => void;
   aiEnabled?: boolean;
   themeVersion?: number;
 }
@@ -80,7 +80,7 @@ function CommitSkeleton() {
 
 const SKELETON_MIN_MS = 400;
 
-export function CommitList({ layout, selectedHash, repoColors, repos, activeRepoId, currentBranchByRepo, headHashByRepo, onSelect, onLoadMore, hasMore, storeHasMore, loading, backgroundLoading, scrollToHash, onScrolledToHash, aiEnabled }: Props) {
+export function CommitList({ layout, selectedHash, repoColors, repos, activeRepoId, currentBranchByRepo, headHashByRepo, onSelect, onLoadMore, hasMore, storeHasMore, loading, backgroundLoading, scrollTarget, onScrollTargetHandled, aiEnabled }: Props) {
   const { commits, segments, refColors } = layout;
 
   // graphWidth is stable: it only grows, never shrinks, so adding new commits
@@ -224,17 +224,22 @@ export function CommitList({ layout, selectedHash, repoColors, repos, activeRepo
   }, []);
 
   useEffect(() => {
-    if (!scrollToHash) return;
-    const idx = commits.findIndex(c => c.hash === scrollToHash);
+    if (!scrollTarget || showSkeleton) return;
+    const idx = commits.findIndex(c => c.hash === scrollTarget.hash && c.repoId === scrollTarget.repoId);
     if (idx >= 0) {
       virtualizer.scrollToIndex(idx, { align: 'center' });
+      setMultiSelectHashes(new Set());
       onSelect(commits[idx]);
-      onScrolledToHash?.();
+      onScrollTargetHandled?.();
       return;
     }
-    // Commit not yet in the loaded list — keep fetching batches until found or exhausted
-    if (hasMore && !loading) onLoadMore();
-  }, [scrollToHash, commits, hasMore, loading]);
+    // Commit not yet in the loaded list — keep fetching batches until found or exhausted.
+    if (hasMore && !loading) {
+      onLoadMore();
+    } else if (!hasMore && !loading) {
+      onScrollTargetHandled?.();
+    }
+  }, [scrollTarget, commits, hasMore, loading, showSkeleton]);
 
   const anyExpanded = expandedRepos.size > 0;
   const labelColWidth = multiRepo ? (anyExpanded ? REPO_LABEL_WIDTH_EXPANDED + 6 : REPO_LABEL_WIDTH + 8) : 0;

--- a/src/webview/gitLog/main.tsx
+++ b/src/webview/gitLog/main.tsx
@@ -101,7 +101,7 @@ function App() {
           break;
         case 'LOG_SCROLL_TO_COMMIT':
           filterRepoRef.current(msg.repoId, null);
-          store.setPendingScrollHash(msg.hash);
+          store.setPendingScrollTarget({ hash: msg.hash, repoId: msg.repoId });
           break;
         case 'LOG_FILTER_BY_REPO':
           filterRepoRef.current(msg.repoId, msg.branch ?? null);
@@ -379,10 +379,16 @@ function App() {
           tags={sidebarTags}
           filter={store.branchFilter}
           selectedBranchFilter={store.commitFilters.branch}
+          activeRepoId={store.commitFilters.repoId}
           onFilterChange={store.setBranchFilter}
           onBranchFilterSelect={useCallback((branchName: string) => {
             handleFilterChange('branch', branchName);
           }, [handleFilterChange])}
+          onBranchFocus={(branch) => {
+            if (branch.lastCommitHash) {
+              store.setPendingScrollTarget({ hash: branch.lastCommitHash, repoId: branch.repoId });
+            }
+          }}
           onCheckout={(repoIds, branch) => {
             repoIds.forEach(repoId => {
               getVsCodeApi().postMessage({ type: 'LOG_CHECKOUT', requestId: generateId(), repoId, branchName: branch } satisfies LogToHostMsg);
@@ -445,8 +451,8 @@ function App() {
             storeHasMore={store.hasMore}
             loading={store.loadingCommits}
             backgroundLoading={store.backgroundLoading}
-            scrollToHash={store.pendingScrollHash}
-            onScrolledToHash={() => store.setPendingScrollHash(null)}
+            scrollTarget={store.pendingScrollTarget}
+            onScrollTargetHandled={() => store.setPendingScrollTarget(null)}
             aiEnabled={store.aiEnabled}
             themeVersion={themeVersion}
           />

--- a/src/webview/gitLog/store/logStore.ts
+++ b/src/webview/gitLog/store/logStore.ts
@@ -32,7 +32,7 @@ interface LogState {
   branchFilter: string;
   commitFilters: CommitFilters;
   error: string | null;
-  pendingScrollHash: string | null;
+  pendingScrollTarget: { hash: string; repoId: string } | null;
   fileLoadSeq: number;
   stashes: CommitNode[];
 
@@ -58,7 +58,7 @@ interface LogState {
   setCommitFilters: (filters: Partial<CommitFilters>) => void;
   updateBranches: (repoId: string, branches: BranchInfo[]) => void;
   setError: (err: string | null) => void;
-  setPendingScrollHash: (hash: string | null) => void;
+  setPendingScrollTarget: (target: { hash: string; repoId: string } | null) => void;
   setStashes: (stashes: CommitNode[]) => void;
 }
 
@@ -95,7 +95,7 @@ export const useLogStore = create<LogState>((set, get) => ({
   branchFilter: '',
   commitFilters: { ...defaultCommitFilters },
   error: null,
-  pendingScrollHash: null,
+  pendingScrollTarget: null,
   fileLoadSeq: 0,
 
   setRepos: (repos, hasWorkspaceFolder, aiEnabled) => set({ repos, initialized: true, ...(hasWorkspaceFolder !== undefined ? { hasWorkspaceFolder } : {}), ...(aiEnabled !== undefined ? { aiEnabled } : {}) }),
@@ -127,6 +127,6 @@ export const useLogStore = create<LogState>((set, get) => ({
     branches: [...s.branches.filter(b => b.repoId !== repoId), ...branches],
   })),
   setError: (err) => set({ error: err }),
-  setPendingScrollHash: (hash) => set({ pendingScrollHash: hash }),
+  setPendingScrollTarget: (target) => set({ pendingScrollTarget: target }),
   setStashes: (stashes) => set({ stashes }),
 }));

--- a/src/webview/undockedPanel/main.tsx
+++ b/src/webview/undockedPanel/main.tsx
@@ -111,7 +111,7 @@ function LogApp() {
           store.setStashes(msg.stashCommits);
           break;
         case 'LOG_SCROLL_TO_COMMIT':
-          store.setPendingScrollHash(msg.hash);
+          store.setPendingScrollTarget({ hash: msg.hash, repoId: msg.repoId });
           break;
         case 'LOG_FILTER_BY_REPO':
           filterRepoRef.current(msg.repoId, msg.branch ?? null);
@@ -302,8 +302,14 @@ function LogApp() {
           tags={store.tags}
           filter={store.branchFilter}
           selectedBranchFilter={store.commitFilters.branch}
+          activeRepoId={store.commitFilters.repoId}
           onFilterChange={store.setBranchFilter}
           onBranchFilterSelect={useCallback((b: string) => handleFilterChange('branch', b), [handleFilterChange])}
+          onBranchFocus={(branch) => {
+            if (branch.lastCommitHash) {
+              store.setPendingScrollTarget({ hash: branch.lastCommitHash, repoId: branch.repoId });
+            }
+          }}
           onCheckout={(repoIds, branch) => repoIds.forEach(repoId => getVsCodeApi().postMessage({ type: 'LOG_CHECKOUT', requestId: generateId(), repoId, branchName: branch } satisfies LogToHostMsg))}
           onMerge={(repoId, from) => getVsCodeApi().postMessage({ type: 'LOG_MERGE', requestId: generateId(), repoId, from } satisfies LogToHostMsg)}
           onRebase={(repoId, onto) => getVsCodeApi().postMessage({ type: 'LOG_REBASE', requestId: generateId(), repoId, onto } satisfies LogToHostMsg)}
@@ -328,9 +334,10 @@ function LogApp() {
           />
           <CommitList
             layout={graphLayout}
-            selectedHash={store.selectedCommit?.hash ?? null}
+            selectedHash={store.selectedCommit ? `${store.selectedCommit.hash}:${store.selectedCommit.repoId}` : null}
             repoColors={repoColors}
             repos={store.repos}
+            activeRepoId={store.commitFilters.repoId}
             currentBranchByRepo={currentBranchByRepo}
             headHashByRepo={headHashByRepo}
             onSelect={(commit) => { store.selectCommit(commit); setDetailCollapsed(false); }}
@@ -339,8 +346,8 @@ function LogApp() {
             storeHasMore={store.hasMore}
             loading={store.loadingCommits}
             backgroundLoading={store.backgroundLoading}
-            scrollToHash={store.pendingScrollHash}
-            onScrolledToHash={() => store.setPendingScrollHash(null)}
+            scrollTarget={store.pendingScrollTarget}
+            onScrollTargetHandled={() => store.setPendingScrollTarget(null)}
             aiEnabled={store.aiEnabled}
             themeVersion={themeVersion}
           />


### PR DESCRIPTION
## Problem

Branch rows in the Git Log sidebar could filter history or open Git actions, but they could not navigate the commit graph to the branch head. Locating a branch head manually was especially inconvenient in large or multi-repository histories.

## Summary

- Single-click a local or remote branch row to center and select its head commit
- Update the commit detail panel with the selected branch-head commit
- Retain double-click branch filtering and right-click Git actions
- Keep active text, author, branch, date, and repository filters unchanged
- Identify navigation targets by repository ID and commit hash
- Load additional history until the target is found or available history is exhausted
- Prefer the active repository when a merged branch row represents multiple repositories
- Otherwise select the branch instance with the latest commit date
- Use repository name as a stable tie-breaker
- Avoid repository prompts during navigation
- Support both docked and undocked Git Log views
- Correct interleaved multi-repository pagination so lazy loading does not skip commits
- Wait for the real commit list to replace its loading skeleton before scrolling

## Validation

- `npm run typecheck`
- `npm run typecheck:webview`
- `npm run build`
- `git diff --check`