### PR TITLE
feat: persist the default GitCharm Log location

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ On first install, a QuickPick lets you choose your preferred view mode. You can 
   - **Undock in New Window (Log & Commit)** — same layout in a separate VS Code window.
   - **Undock in Editor Tab** — editor tab with the Git Log only.
   - **Undock in New Window** — separate window with the Git Log only.
+- **Default Location…** in the same burger menu (or `GitCharm: Set Default Git Log Location` in the Command Palette) does the same thing, but *remembers* the choice: Bottom Panel, Editor Tab (Log & Commit / Only Log), or New Window (Log & Commit / Only Log). The picked location applies immediately and is written to `gitcharm.gitLogDefaultLocation` / `gitcharm.gitLogDefaultLayout`, so `GitCharm: Focus Git Log` and its keyboard shortcut (`Ctrl/Cmd+Alt+L`) reopen the Log there — even after you close the editor tab or restart VS Code.
+  - **Undock…** is session-only and never changes the setting; **Default Location…** is the persistent counterpart.
 - State is fully synchronised with the sidebar panels: commits, branches, and status update in real time in both views.
 - The undocked tab shows the same toolbar actions as the Commit Panel (Fetch All, Pull All, Push All, Sync All, Branch Menu, Settings).
 
@@ -262,6 +264,7 @@ Use the Status Bar branch menu for fast project-wide actions such as updating al
 | `GitCharm: Open Git Annotations` | Shows inline blame annotations in the active editor. |
 | `GitCharm: Close Git Annotations` | Hides inline blame annotations in the active editor. |
 | `GitCharm: Undock` | Opens a QuickPick to undock the Git Log (with or without the Commit Panel) into an editor tab or a new window. |
+| `GitCharm: Set Default Git Log Location` | Opens a QuickPick to choose — and persist — where the Git Log opens: bottom panel, editor tab, or a new window. |
 | `GitCharm: Select AI Provider` | Opens a QuickPick to choose and configure the AI provider and model. |
 | `GitCharm: Generate Commit Message` | Generates an AI commit message from the current staged diff. |
 | `GitCharm: Explain Commit` | Opens the commit detail panel with an AI-generated explanation of the selected commit. |
@@ -283,6 +286,8 @@ Use the Status Bar branch menu for fast project-wide actions such as updating al
 | `gitcharm.repositoryScanMaxDepth` | `1` | Maximum depth of workspace subfolders to scan for Git repositories. `0` only checks workspace folders. |
 | `gitcharm.repositoryScanIgnoredFolders` | `["node_modules"]` | Folder names or workspace-relative paths skipped while scanning for nested Git repositories. |
 | `gitcharm.autoRefreshInterval` | `0` | Auto-refresh interval in seconds. `0` disables interval refresh and uses file watchers only. |
+| `gitcharm.gitLogDefaultLocation` | `"panel"` | Where `GitCharm: Focus Git Log` opens the Log: `panel`, `editorTab`, or `newWindow`. |
+| `gitcharm.gitLogDefaultLayout` | `"logAndCommit"` | What the Log shows outside the bottom panel: `logAndCommit` or `logOnly`. Ignored when the location is `panel`. |
 | `gitcharm.changesViewMode` | `"simplified"` | How to display changed files: `simplified`, `changelists`, or `vscode`. Chosen via QuickPick on first install. |
 | `gitcharm.gitAnnotations.enabled` | `true` | Enable inline Git blame annotations in the editor. |
 | `gitcharm.gitGhostText.enabled` | `true` | Enable inline Git ghost text in the editor. |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ On first install, a QuickPick lets you choose your preferred view mode. You can 
   - **Undock in New Window** — separate window with the Git Log only.
 - **Default Location…** in the same burger menu (or `GitCharm: Set Default Git Log Location` in the Command Palette) does the same thing, but *remembers* the choice: Bottom Panel, Editor Tab (Log & Commit / Only Log), or New Window (Log & Commit / Only Log). The picked location applies immediately and is written to `gitcharm.gitLogDefaultLocation` / `gitcharm.gitLogDefaultLayout`, so `GitCharm: Focus Git Log` and its keyboard shortcut (`Ctrl/Cmd+Alt+L`) reopen the Log there — even after you close the editor tab or restart VS Code.
   - **Undock…** is session-only and never changes the setting; **Default Location…** is the persistent counterpart.
+  - Picking anything other than **Bottom Panel** also removes the GitCharm Log view from the bottom panel, so you never end up with two Log surfaces. Switching back restores it.
 - State is fully synchronised with the sidebar panels: commits, branches, and status update in real time in both views.
 - The undocked tab shows the same toolbar actions as the Commit Panel (Fetch All, Pull All, Push All, Sync All, Branch Menu, Settings).
 
@@ -286,7 +287,7 @@ Use the Status Bar branch menu for fast project-wide actions such as updating al
 | `gitcharm.repositoryScanMaxDepth` | `1` | Maximum depth of workspace subfolders to scan for Git repositories. `0` only checks workspace folders. |
 | `gitcharm.repositoryScanIgnoredFolders` | `["node_modules"]` | Folder names or workspace-relative paths skipped while scanning for nested Git repositories. |
 | `gitcharm.autoRefreshInterval` | `0` | Auto-refresh interval in seconds. `0` disables interval refresh and uses file watchers only. |
-| `gitcharm.gitLogDefaultLocation` | `"panel"` | Where `GitCharm: Focus Git Log` opens the Log: `panel`, `editorTab`, or `newWindow`. |
+| `gitcharm.gitLogDefaultLocation` | `"panel"` | Where `GitCharm: Focus Git Log` opens the Log: `panel`, `editorTab`, or `newWindow`. Anything but `panel` also hides the Log view from the bottom panel. |
 | `gitcharm.gitLogDefaultLayout` | `"logAndCommit"` | What the Log shows outside the bottom panel: `logAndCommit` or `logOnly`. Ignored when the location is `panel`. |
 | `gitcharm.changesViewMode` | `"simplified"` | How to display changed files: `simplified`, `changelists`, or `vscode`. Chosen via QuickPick on first install. |
 | `gitcharm.gitAnnotations.enabled` | `true` | Enable inline Git blame annotations in the editor. |

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
           "type": "webview",
           "id": "gitcharm.gitLog",
           "name": "Git Log",
-          "retainContextWhenHidden": true
+          "retainContextWhenHidden": true,
+          "when": "!gitcharm.gitLogDefaultUndocked"
         }
       ]
     },
@@ -891,7 +892,7 @@
               "Open the GitCharm Log in a separate window"
             ],
             "default": "panel",
-            "description": "Where the GitCharm Log opens when you run 'GitCharm: Focus Git Log' or press its keyboard shortcut. The 'Undock…' menu item still moves the Log for the current session only, without changing this setting.",
+            "description": "Where the GitCharm Log opens when you run 'GitCharm: Focus Git Log' or press its keyboard shortcut. Anything other than 'panel' also hides the GitCharm Log view from the bottom panel, so there is only ever one Log surface. The 'Undock…' menu item still moves the Log for the current session only, without changing this setting.",
             "scope": "window"
           },
           "gitcharm.gitLogDefaultLayout": {

--- a/package.json
+++ b/package.json
@@ -342,6 +342,12 @@
         "icon": "$(multiple-windows)"
       },
       {
+        "command": "gitcharm.setGitLogDefaultLocation",
+        "title": "Set Default Git Log Location",
+        "category": "GitCharm",
+        "icon": "$(settings-gear)"
+      },
+      {
         "command": "gitcharm.showFileHistory",
         "title": "Show File History",
         "category": "GitCharm",
@@ -631,6 +637,9 @@
           "command": "gitcharm.undock"
         },
         {
+          "command": "gitcharm.setGitLogDefaultLocation"
+        },
+        {
           "command": "gitcharm.submodule.init"
         },
         {
@@ -867,6 +876,38 @@
             "type": "boolean",
             "default": true,
             "description": "Enable inline Git ghost text in the editor."
+          },
+          "gitcharm.gitLogDefaultLocation": {
+            "order": 12,
+            "type": "string",
+            "enum": [
+              "panel",
+              "editorTab",
+              "newWindow"
+            ],
+            "enumDescriptions": [
+              "Open the GitCharm Log in the bottom panel, next to the terminal",
+              "Open the GitCharm Log as an editor tab",
+              "Open the GitCharm Log in a separate window"
+            ],
+            "default": "panel",
+            "description": "Where the GitCharm Log opens when you run 'GitCharm: Focus Git Log' or press its keyboard shortcut. The 'Undock…' menu item still moves the Log for the current session only, without changing this setting.",
+            "scope": "window"
+          },
+          "gitcharm.gitLogDefaultLayout": {
+            "order": 13,
+            "type": "string",
+            "enum": [
+              "logAndCommit",
+              "logOnly"
+            ],
+            "enumDescriptions": [
+              "Show the Git Log and the Commit panel side by side",
+              "Show only the Git Log"
+            ],
+            "default": "logAndCommit",
+            "description": "What the GitCharm Log shows when it opens outside the bottom panel. Ignored when 'Git Log Default Location' is 'panel'.",
+            "scope": "window"
           },
           "gitcharm.changesViewMode": {
             "order": 10,

--- a/src/host/commands/registerCommands.ts
+++ b/src/host/commands/registerCommands.ts
@@ -22,9 +22,14 @@ export function registerCommands(
   extensionUri?: vscode.Uri,
 ): void {
   context.subscriptions.push(
-    // Focus the Git Log panel in the bottom bar
+    // Open the Git Log where the persisted default location says
     vscode.commands.registerCommand('gitcharm.openLog', () => {
-      logPanel.focus();
+      logPanel.openPreferred();
+    }),
+
+    // Pick and persist where the Git Log opens by default
+    vscode.commands.registerCommand('gitcharm.setGitLogDefaultLocation', () => {
+      void logPanel.triggerDefaultLocationPick();
     }),
 
     // Show the GitCharm output channel (full error/event log)

--- a/src/host/extension.ts
+++ b/src/host/extension.ts
@@ -4,6 +4,7 @@ import { CommitPanelProvider } from './panels/CommitPanelProvider';
 import { GitLogPanelProvider } from './panels/GitLogPanelProvider';
 import { MergeEditorProvider } from './panels/MergeEditorProvider';
 import { UndockedPanelProvider } from './panels/UndockedPanelProvider';
+import { syncGitLogLocationContext, watchGitLogLocationContext } from './settings/GitLogLocationSettings';
 import { BranchStatusBar } from './ui/BranchStatusBar';
 import { BadgeController } from './ui/BadgeController';
 import { registerCommands } from './commands/registerCommands';
@@ -186,6 +187,10 @@ async function maybeNotifyIncomingCommits(manager: WorkspaceGitManager, globalSt
 
 export function activate(context: vscode.ExtensionContext): void {
   const log = initLogger(context);
+  // Set before any view renders: hides the bottom-panel Git Log view while the
+  // Log's default home is an editor tab or a separate window, so there is only
+  // ever one Log surface.
+  syncGitLogLocationContext();
   const manager = new WorkspaceGitManager(context);
 
   // DEV ONLY: uncomment to reset the quickpick flag
@@ -231,6 +236,11 @@ export function activate(context: vscode.ExtensionContext): void {
   commitPanel.setUndockedPanel(undockedPanel);
   logPanel.setCommitPanel(commitPanel);
   logPanel.setUndockedPanel(undockedPanel);
+  // Changing the setting from the Settings UI: switching back to the bottom
+  // panel should tear down the undocked surface, same as the QuickPick does.
+  context.subscriptions.push(
+    watchGitLogLocationContext(undocked => { if (!undocked) undockedPanel.close(); }),
+  );
 
   // Apply saved hidden repos to badge immediately (before webview opens)
   const savedHidden = commitPanel.getHiddenRepoIds();

--- a/src/host/panels/GitLogPanelProvider.ts
+++ b/src/host/panels/GitLogPanelProvider.ts
@@ -12,6 +12,13 @@ import { openEditMessageEditor } from './EditMessageEditorPanel';
 import { formatGitError, showGitError, getRawErrorDetail } from '../utils/gitErrorUtils';
 import { pickRefQuickPick } from '../utils/refPicker';
 import { logInfo, logWarn, logError, showLogChannel } from '../utils/Logger';
+import {
+  getGitLogDefaultLayout,
+  getGitLogDefaultLocation,
+  setGitLogDefault,
+  type GitLogLayout,
+  type GitLogLocation,
+} from '../settings/GitLogLocationSettings';
 
 function mergeCurrentIntoBranches(branches: BranchInfo[], current: BranchInfo): BranchInfo[] {
   if (!current.detachedTag && !current.detachedHash) return branches; // normal branch — already in list
@@ -114,6 +121,54 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
     );
     if (!pick) return;
     this.undockedPanel.open(pick.value, pick.showCommit);
+  }
+
+  /**
+   * Open the Git Log where the persisted default says — bottom panel, editor tab
+   * or a separate window. Used by `gitcharm.openLog` (command + keybinding).
+   */
+  openPreferred(): void {
+    const location = getGitLogDefaultLocation();
+    if (location === 'panel' || !this.undockedPanel) {
+      this.focus();
+      return;
+    }
+    this.undockedPanel.open(location, getGitLogDefaultLayout() === 'logAndCommit');
+  }
+
+  /** Ask for — and persist — the default Git Log location, then apply it right away. */
+  async triggerDefaultLocationPick(): Promise<void> {
+    type Item = vscode.QuickPickItem & { location: GitLogLocation; layout: GitLogLayout };
+    const currentLocation = getGitLogDefaultLocation();
+    const currentLayout = getGitLogDefaultLayout();
+
+    const items: Item[] = [
+      { label: '$(layout-panel) Bottom Panel', location: 'panel', layout: currentLayout },
+      { label: '$(editor-layout) Editor Tab (Log & Commit)', location: 'editorTab', layout: 'logAndCommit' },
+      { label: '$(editor-layout) Editor Tab (Only Log)', location: 'editorTab', layout: 'logOnly' },
+      { label: '$(empty-window) New Window (Log & Commit)', location: 'newWindow', layout: 'logAndCommit' },
+      { label: '$(empty-window) New Window (Only Log)', location: 'newWindow', layout: 'logOnly' },
+    ];
+    for (const item of items) {
+      const isCurrent = item.location === currentLocation
+        && (item.location === 'panel' || item.layout === currentLayout);
+      if (isCurrent) item.description = 'current default';
+    }
+
+    const pick = await vscode.window.showQuickPick<Item>(items, {
+      title: 'Default GitCharm Log Location',
+      placeHolder: 'Where should the Git Log open from now on?',
+    });
+    if (!pick) return;
+
+    await setGitLogDefault(pick.location, pick.layout);
+
+    if (pick.location === 'panel') {
+      this.undockedPanel?.close();
+      this.focus();
+    } else {
+      this.undockedPanel?.open(pick.location, pick.layout === 'logAndCommit');
+    }
   }
 
   handleUndockedMessage(msg: LogToHostMsg, _provider: UndockedPanelProvider): void {
@@ -1626,6 +1681,11 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
         } else {
           this.undockedPanel.open(msg.target);
         }
+        break;
+      }
+
+      case 'LOG_SET_DEFAULT_LOCATION': {
+        await this.triggerDefaultLocationPick();
         break;
       }
     }

--- a/src/host/panels/GitLogPanelProvider.ts
+++ b/src/host/panels/GitLogPanelProvider.ts
@@ -98,6 +98,11 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
   private pendingScrollRepoId: string | null = null;
   // When set, post() sends to the undocked panel instead of the sidebar
   private activeReplyTarget: 'sidebar' | 'undocked' = 'sidebar';
+  // Scroll/filter intents queued while a freshly opened undocked panel boots up.
+  private pendingUndocked: {
+    scroll?: { hash: string; repoId: string };
+    filter?: { repoId: string; branch: string | null };
+  } | null = null;
 
   setCommitPanel(provider: CommitPanelProvider): void {
     this.commitPanel = provider;
@@ -128,12 +133,25 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
    * or a separate window. Used by `gitcharm.openLog` (command + keybinding).
    */
   openPreferred(): void {
+    this.revealPreferred();
+  }
+
+  /**
+   * Reveal the Git Log on whichever surface the default location points at.
+   * `wasOpen` tells callers whether the surface was already live, so they know
+   * if a follow-up message can be posted right away or has to be queued until
+   * the webview has booted and asked for its first batch of commits.
+   */
+  private revealPreferred(): { target: 'sidebar' | 'undocked'; wasOpen: boolean } {
     const location = getGitLogDefaultLocation();
     if (location === 'panel' || !this.undockedPanel) {
+      const wasOpen = this.view?.visible === true;
       this.focus();
-      return;
+      return { target: 'sidebar', wasOpen };
     }
+    const wasOpen = this.undockedPanel.isOpen();
     this.undockedPanel.open(location, getGitLogDefaultLayout() === 'logAndCommit');
+    return { target: 'undocked', wasOpen };
   }
 
   /** Ask for — and persist — the default Git Log location, then apply it right away. */
@@ -165,7 +183,9 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
 
     if (pick.location === 'panel') {
       this.undockedPanel?.close();
-      this.focus();
+      // The view's `when` clause has just flipped back on — give the workbench a
+      // tick to re-register the panel container before focusing it.
+      setTimeout(() => this.focus(), 100);
     } else {
       this.undockedPanel?.open(pick.location, pick.layout === 'logAndCommit');
     }
@@ -298,28 +318,47 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
     vscode.commands.executeCommand(`${GitLogPanelProvider.viewType}.focus`);
   }
 
-  /** Focus the panel and scroll to a specific commit. */
+  /** Reveal the Git Log (wherever it lives) and scroll to a specific commit. */
   selectCommit(hash: string, repoId: string): void {
+    const { target, wasOpen } = this.revealPreferred();
+
+    if (target === 'undocked') {
+      if (wasOpen) {
+        // postToLog, not post(): the timeout fires after activeReplyTarget resets.
+        setTimeout(() => this.undockedPanel?.postToLog({ type: 'LOG_SCROLL_TO_COMMIT', hash, repoId }), 150);
+      } else {
+        this.pendingUndocked = { ...this.pendingUndocked, scroll: { hash, repoId } };
+      }
+      return;
+    }
+
+    if (wasOpen) {
+      setTimeout(() => this.post({ type: 'LOG_SCROLL_TO_COMMIT', hash, repoId }), 150);
+      return;
+    }
     this.pendingScrollHash = hash;
     this.pendingScrollRepoId = repoId;
-    this.focus();
-    if (this.view?.visible) {
-      this.pendingScrollHash = null;
-      this.pendingScrollRepoId = null;
-      setTimeout(() => this.post({ type: 'LOG_SCROLL_TO_COMMIT', hash, repoId }), 150);
-    }
   }
 
-  /** Focus the panel and filter the log to a specific repository (and optionally branch). */
+  /** Reveal the Git Log and filter it to a specific repository (and optionally branch). */
   focusRepo(repoId: string, branch?: string): void {
+    const { target, wasOpen } = this.revealPreferred();
+
+    if (target === 'undocked') {
+      if (wasOpen) {
+        setTimeout(() => this.undockedPanel?.postToLog({ type: 'LOG_FILTER_BY_REPO', repoId, branch }), 150);
+      } else {
+        this.pendingUndocked = { ...this.pendingUndocked, filter: { repoId, branch: branch ?? null } };
+      }
+      return;
+    }
+
+    if (wasOpen) {
+      this.post({ type: 'LOG_FILTER_BY_REPO', repoId, branch });
+      return;
+    }
     this.pendingFilterRepoId = repoId;
     this.pendingFilterBranch = branch ?? null;
-    this.focus();
-    if (this.view?.visible) {
-      this.post({ type: 'LOG_FILTER_BY_REPO', repoId, branch });
-      this.pendingFilterRepoId = null;
-      this.pendingFilterBranch = null;
-    }
   }
 
   /** Trigger a full log refresh — call this after any operation that creates new commits. */
@@ -380,9 +419,14 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
         const limit = Math.min(msg.limit, maxCommits);
 
         const repos = this.getVisibleRepos();
+        // Resolve the icon theme against the webview that asked, so the undocked
+        // panel still gets file icons when the bottom-panel view is hidden.
+        const iconWebview = this.activeReplyTarget === 'undocked'
+          ? this.undockedPanel?.webview
+          : this.view?.webview;
         const [branches, iconTheme] = await Promise.all([
           this.getFilteredBranches(),
-          this.view ? loadIconTheme(this.view.webview) : Promise.resolve(undefined),
+          iconWebview ? loadIconTheme(iconWebview) : Promise.resolve(undefined),
         ]);
         this.post({ type: 'LOG_INIT_DATA', repos, branches, iconTheme });
 
@@ -406,6 +450,22 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
           filterDateTo: msg.filterDateTo,
         });
         this.post({ type: 'LOG_COMMITS_BATCH', commits, isLast: commits.length < limit, batchIndex: 0, requestId: msg.requestId });
+
+        // A freshly opened undocked panel is only ready once it has asked for commits.
+        if (msg.skip === 0 && this.activeReplyTarget === 'undocked' && this.pendingUndocked) {
+          const queued = this.pendingUndocked;
+          this.pendingUndocked = null;
+          setTimeout(() => {
+            if (queued.filter) {
+              const { repoId, branch } = queued.filter;
+              this.undockedPanel?.postToLog({ type: 'LOG_FILTER_BY_REPO', repoId, branch });
+            }
+            if (queued.scroll) {
+              const { hash, repoId } = queued.scroll;
+              this.undockedPanel?.postToLog({ type: 'LOG_SCROLL_TO_COMMIT', hash, repoId });
+            }
+          }, 150);
+        }
 
         // Send stashes only on first load (not on pagination)
         if (msg.skip === 0) {

--- a/src/host/panels/UndockedPanelProvider.ts
+++ b/src/host/panels/UndockedPanelProvider.ts
@@ -120,6 +120,11 @@ export class UndockedPanelProvider implements vscode.Disposable {
     return this.panel !== null;
   }
 
+  /** Close the undocked panel, if open. onDidDispose resets the internal state. */
+  close(): void {
+    this.panel?.dispose();
+  }
+
   dispose(): void {
     this.panel?.dispose();
     this.disposables.forEach(d => d.dispose());

--- a/src/host/panels/UndockedPanelProvider.ts
+++ b/src/host/panels/UndockedPanelProvider.ts
@@ -120,6 +120,11 @@ export class UndockedPanelProvider implements vscode.Disposable {
     return this.panel !== null;
   }
 
+  /** The undocked webview, for callers that need to build webview resource URIs. */
+  get webview(): vscode.Webview | undefined {
+    return this.panel?.webview;
+  }
+
   /** Close the undocked panel, if open. onDidDispose resets the internal state. */
   close(): void {
     this.panel?.dispose();

--- a/src/host/settings/GitLogLocationSettings.ts
+++ b/src/host/settings/GitLogLocationSettings.ts
@@ -1,0 +1,48 @@
+import * as vscode from 'vscode';
+
+/** Where the GitCharm Log opens by default when triggered by command or keybinding. */
+export const GIT_LOG_LOCATIONS = ['panel', 'editorTab', 'newWindow'] as const;
+export type GitLogLocation = (typeof GIT_LOG_LOCATIONS)[number];
+
+/** Which sub-apps the undocked GitCharm Log shows. Ignored when the location is 'panel'. */
+export const GIT_LOG_LAYOUTS = ['logAndCommit', 'logOnly'] as const;
+export type GitLogLayout = (typeof GIT_LOG_LAYOUTS)[number];
+
+export const DEFAULT_GIT_LOG_LOCATION: GitLogLocation = 'panel';
+export const DEFAULT_GIT_LOG_LAYOUT: GitLogLayout = 'logAndCommit';
+
+const CONFIG_SECTION = 'gitcharm';
+const LOCATION_KEY = 'gitLogDefaultLocation';
+const LAYOUT_KEY = 'gitLogDefaultLayout';
+
+function isLocation(value: unknown): value is GitLogLocation {
+  return typeof value === 'string' && (GIT_LOG_LOCATIONS as readonly string[]).includes(value);
+}
+
+function isLayout(value: unknown): value is GitLogLayout {
+  return typeof value === 'string' && (GIT_LOG_LAYOUTS as readonly string[]).includes(value);
+}
+
+export function getGitLogDefaultLocation(): GitLogLocation {
+  const raw = vscode.workspace.getConfiguration(CONFIG_SECTION).get<string>(LOCATION_KEY, DEFAULT_GIT_LOG_LOCATION);
+  return isLocation(raw) ? raw : DEFAULT_GIT_LOG_LOCATION;
+}
+
+export function getGitLogDefaultLayout(): GitLogLayout {
+  const raw = vscode.workspace.getConfiguration(CONFIG_SECTION).get<string>(LAYOUT_KEY, DEFAULT_GIT_LOG_LAYOUT);
+  return isLayout(raw) ? raw : DEFAULT_GIT_LOG_LAYOUT;
+}
+
+/**
+ * Persist the default location. Writes to the workspace when the key is already
+ * overridden there, otherwise to user settings so the choice follows the user.
+ */
+export async function setGitLogDefault(location: GitLogLocation, layout: GitLogLayout): Promise<void> {
+  const cfg = vscode.workspace.getConfiguration(CONFIG_SECTION);
+  const hasWorkspaceOverride =
+    cfg.inspect(LOCATION_KEY)?.workspaceValue !== undefined ||
+    cfg.inspect(LAYOUT_KEY)?.workspaceValue !== undefined;
+  const target = hasWorkspaceOverride ? vscode.ConfigurationTarget.Workspace : vscode.ConfigurationTarget.Global;
+  await cfg.update(LOCATION_KEY, location, target);
+  await cfg.update(LAYOUT_KEY, layout, target);
+}

--- a/src/host/settings/GitLogLocationSettings.ts
+++ b/src/host/settings/GitLogLocationSettings.ts
@@ -46,3 +46,27 @@ export async function setGitLogDefault(location: GitLogLocation, layout: GitLogL
   await cfg.update(LOCATION_KEY, location, target);
   await cfg.update(LAYOUT_KEY, layout, target);
 }
+
+/** True when the default location puts the Log outside the bottom panel. */
+export function isGitLogDefaultUndocked(): boolean {
+  return getGitLogDefaultLocation() !== 'panel';
+}
+
+/**
+ * Mirror the default location into the `gitcharm.gitLogDefaultUndocked` context
+ * key, which package.json uses to hide the bottom-panel Git Log view when the
+ * Log lives in an editor tab or its own window. Call this as early as possible
+ * in activation, before VS Code evaluates the view's `when` clause.
+ */
+export function syncGitLogLocationContext(): void {
+  void vscode.commands.executeCommand('setContext', 'gitcharm.gitLogDefaultUndocked', isGitLogDefaultUndocked());
+}
+
+/** Keep the context key in sync when the setting changes from the Settings UI. */
+export function watchGitLogLocationContext(onChange?: (undocked: boolean) => void): vscode.Disposable {
+  return vscode.workspace.onDidChangeConfiguration(e => {
+    if (!e.affectsConfiguration(`${CONFIG_SECTION}.${LOCATION_KEY}`)) return;
+    syncGitLogLocationContext();
+    onChange?.(isGitLogDefaultUndocked());
+  });
+}

--- a/src/host/types/messages.ts
+++ b/src/host/types/messages.ts
@@ -293,6 +293,7 @@ export type LogToHostMsg =
   | { type: 'LOG_STASH_APPLY'; requestId: string; repoId: string; stashRef: string }
   | { type: 'LOG_STASH_DROP'; requestId: string; repoId: string; stashRef: string }
   | { type: 'LOG_UNDOCK'; target: 'editorTab' | 'newWindow' | 'pick' }
+  | { type: 'LOG_SET_DEFAULT_LOCATION' }
   | { type: 'LOG_VIEW_COMBINED_DIFF'; repoId: string; hashes: string[] }
   | { type: 'LOG_COMPARE_COMMIT_WITH'; repoId: string; hash: string }
   | { type: 'LOG_COMPARE_FILE_WITH'; repoId: string; hash: string; filePath: string };

--- a/src/webview/gitLog/components/CommitFiltersBar.tsx
+++ b/src/webview/gitLog/components/CommitFiltersBar.tsx
@@ -15,6 +15,8 @@ interface Props {
   onUndock?: (target: 'editorTab' | 'newWindow' | 'pick') => void;
   /** When true, hides the Undock menu item (already in undocked mode). */
   hideUndock?: boolean;
+  /** Opens the picker that persists where the Git Log opens by default. */
+  onSetDefaultLocation?: () => void;
 }
 
 function useIsLightTheme() {
@@ -27,7 +29,7 @@ function useIsLightTheme() {
   return light;
 }
 
-export function CommitFiltersBar({ filters, branches, tags, repos, onFilterChange, onRepoChange, onClear, onFetchAll, onUndock, hideUndock }: Props) {
+export function CommitFiltersBar({ filters, branches, tags, repos, onFilterChange, onRepoChange, onClear, onFetchAll, onUndock, hideUndock, onSetDefaultLocation }: Props) {
   const isLight = useIsLightTheme();
   useEffect(() => {
     const id = 'gitcharm-filter-field-focus';
@@ -118,17 +120,18 @@ export function CommitFiltersBar({ filters, branches, tags, repos, onFilterChang
         )}
 
         {/* More menu — pushed to the right */}
-        <MoreMenu onFetchAll={onFetchAll} onUndock={onUndock} hideUndock={hideUndock} />
+        <MoreMenu onFetchAll={onFetchAll} onUndock={onUndock} hideUndock={hideUndock} onSetDefaultLocation={onSetDefaultLocation} />
       </div>
   );
 }
 
 /* ─── MoreMenu ────────────────────────────────────────────────────────────── */
 
-function MoreMenu({ onFetchAll, onUndock, hideUndock }: {
+function MoreMenu({ onFetchAll, onUndock, hideUndock, onSetDefaultLocation }: {
   onFetchAll: () => void;
   onUndock?: (target: 'editorTab' | 'newWindow' | 'pick') => void;
   hideUndock?: boolean;
+  onSetDefaultLocation?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -168,17 +171,28 @@ function MoreMenu({ onFetchAll, onUndock, hideUndock }: {
             <span>Fetch and Refresh</span>
           </div>
 
+          {(!hideUndock || onSetDefaultLocation) && <div style={styles.moreSeparator} />}
+
           {!hideUndock && (
-            <>
-              <div style={styles.moreSeparator} />
-              <div
-                style={styles.moreItem}
-                onClick={() => { onUndock?.('pick'); setOpen(false); }}
-              >
-                <Codicon name="multiple-windows" style={{ fontSize: '13px', opacity: 0.7 }} />
-                <span>Undock…</span>
-              </div>
-            </>
+            <div
+              style={styles.moreItem}
+              onClick={() => { onUndock?.('pick'); setOpen(false); }}
+              title="Move the Git Log for this session only"
+            >
+              <Codicon name="multiple-windows" style={{ fontSize: '13px', opacity: 0.7 }} />
+              <span>Undock…</span>
+            </div>
+          )}
+
+          {onSetDefaultLocation && (
+            <div
+              style={styles.moreItem}
+              onClick={() => { onSetDefaultLocation(); setOpen(false); }}
+              title="Remember where the Git Log opens from now on"
+            >
+              <Codicon name="settings-gear" style={{ fontSize: '13px', opacity: 0.7 }} />
+              <span>Default Location…</span>
+            </div>
           )}
         </div>
       )}

--- a/src/webview/gitLog/main.tsx
+++ b/src/webview/gitLog/main.tsx
@@ -355,6 +355,7 @@ function App() {
         onClear={handleClearFilters}
         onFetchAll={() => send({ type: 'LOG_FETCH_ALL' })}
         onUndock={(target) => send({ type: 'LOG_UNDOCK', target } as LogToHostMsg)}
+        onSetDefaultLocation={() => send({ type: 'LOG_SET_DEFAULT_LOCATION' } as LogToHostMsg)}
       />
       <RepoTabs
         value={store.commitFilters.repoId}

--- a/src/webview/undockedPanel/main.tsx
+++ b/src/webview/undockedPanel/main.tsx
@@ -284,6 +284,7 @@ function LogApp() {
         onRepoChange={handleRepoChange}
         onClear={handleClearFilters}
         onFetchAll={() => send({ type: 'LOG_FETCH_ALL' })}
+        onSetDefaultLocation={() => send({ type: 'LOG_SET_DEFAULT_LOCATION' })}
         hideUndock
       />
 


### PR DESCRIPTION
## Problem

`Undock…` moves the Git Log into an editor tab or a separate window, but the choice is session-only. Close the undocked tab, press <kbd>Ctrl/Cmd+Alt+L</kbd>, and the Log drops back into the bottom panel — every time.

## What this adds

A persistent counterpart to `Undock…`, which is left untouched and stays non-persistent.

**Two new settings** (Basic Settings):

| Setting | Values | Default |
|:--|:--|:--|
| `gitcharm.gitLogDefaultLocation` | `panel` \| `editorTab` \| `newWindow` | `panel` |
| `gitcharm.gitLogDefaultLayout` | `logAndCommit` \| `logOnly` | `logAndCommit` |

`gitcharm.openLog` reads them, so the command and its keybinding reopen the Log where it was left — after closing the tab, and across restarts.

**Two new entry points:**

- **Default Location…** in the Git Log burger menu, next to `Undock…`. Present in both the docked and undocked views, so the default can be set back to Bottom Panel from inside the editor tab.
- `GitCharm: Set Default Git Log Location` in the Command Palette.

Both open a QuickPick with the five combinations, tag the active one `current default`, persist the choice, and apply it immediately. Writes to user settings unless the key already has a workspace override.

## Hiding the redundant panel view

With the default pointing at an editor tab, leaving the view in the bottom panel means two Log surfaces competing for the same state, plus a stale-looking panel with no reason to open it. The view is now gated on a `gitcharm.gitLogDefaultUndocked` context key, mirrored from the setting and set before any view renders; VS Code hides the empty `gitcharm-log` container. Switching back restores it.

That exposed two paths assuming the sidebar webview always exists, both fixed here:

- **`selectCommit()` / `focusRepo()` were silent no-ops.** They ran `gitcharm.gitLog.focus` and posted to the sidebar, so clicking a commit in the Push tab, the branch status bar, or File History did nothing once the view was hidden. Both now reveal whichever surface the default points at. For a cold undocked panel the scroll/filter intent is queued and flushed when that webview requests its first batch of commits (`skip === 0`), since no fixed delay can know when it has finished booting. Pending state is per-surface so the two cannot consume each other's intent.
- **The undocked panel lost every file icon.** `loadIconTheme()` resolved against `this.view.webview`; with no sidebar view there was nothing to borrow. It now resolves against the webview that made the request. This was already reachable before this PR — undock without ever opening the bottom panel and the icons were missing.

Switching the default back to `panel` from the Settings UI also closes the undocked panel, matching what the QuickPick does.

## Verification

`npm run typecheck`, `npm run typecheck:webview` and `npm run build` are clean. `npm run lint` reports 97 problems, identical to the count on a stashed tree — all pre-existing, none in the touched files.

Manually exercised in the Extension Development Host: default set via both the burger menu and the Settings UI; tab closed and reopened via the keybinding; persistence across a restart; `Undock…` confirmed not to write the setting; both layout variants and the new-window location; the bottom-panel view disappearing and returning; commit selection from the Push tab landing on the right row in a cold editor tab; file icons present in the undocked panel.

Version left at `0.4.5` — happy to bump if you would rather it ship with one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)