### PR TITLE
Adapt commit button to publish/sync when there is nothing to commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ On first install, a QuickPick lets you choose your preferred view mode. You can 
 - Click the **×** on a pill to quickly deselect that repository from the commit.
 - In VS Code mode, a per-repository checkbox in the Staged Changes section controls which repositories are included.
 
+#### Adaptive commit button
+
+When there is nothing left to commit, the primary button turns into the remote action the branch actually needs — no switching to the Push tab:
+
+| Branch state | Button |
+|:--|:--|
+| Uncommitted changes | **Commit** (or **Commit & Push**) |
+| No upstream yet | **Publish Branch** |
+| Ahead and/or behind the upstream | **Sync Changes** with the commit counts and ↑ / ↓ arrows |
+
+**Sync Changes** pushes, pulls, or does both, depending on what the branch needs. When your branch and the remote have diverged — after an amend, rebase, or squash — a QuickPick asks how to reconcile: **Pull, then Push**, **Pull (Rebase), then Push**, or **Force Push** (`--force-with-lease`). If the local history looks rewritten, the force option is listed first. The same prompt appears if a push is rejected because the remote moved. The dropdown always exposes **Push**, **Pull**, and **Force Push** directly.
+
 ### 🚀 Push Tab
 
 - Lists unpushed commits for every repository, including branches without an upstream tracking branch.

--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -1153,6 +1153,46 @@ export class GitService {
     await this.git.remote(['set-url', name, url]);
   }
 
+  /**
+   * Upstream tracking state read straight from git (VS Code's cached HEAD can lag), plus
+   * whether a divergence looks like rewritten history rather than genuine new remote work.
+   */
+  async getUpstreamState(): Promise<{ upstream?: string; ahead: number; behind: number; rewritten: boolean }> {
+    const upstream = (await this.git.raw(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}']).catch(() => '')).trim();
+    if (!upstream) return { ahead: 0, behind: 0, rewritten: false };
+    const [aheadRaw, behindRaw] = await Promise.all([
+      this.git.raw(['rev-list', '--count', `${upstream}..HEAD`]).catch(() => '0'),
+      this.git.raw(['rev-list', '--count', `HEAD..${upstream}`]).catch(() => '0'),
+    ]);
+    const ahead = parseInt(aheadRaw.trim(), 10) || 0;
+    const behind = parseInt(behindRaw.trim(), 10) || 0;
+    const rewritten = ahead > 0 && behind > 0 && await this.isDivergenceRewrite(upstream);
+    return { upstream, ahead, behind, rewritten };
+  }
+
+  /**
+   * True when the commits only the upstream has look like older versions of our own —
+   * the signature of an amend, rebase or squash rather than someone else's new commits.
+   * Checked two ways: patch equivalence (`git cherry` marks those with "-"), which catches
+   * message-only rewrites, and matching subjects, which catches rewrites that changed content.
+   */
+  private async isDivergenceRewrite(upstream: string): Promise<boolean> {
+    try {
+      const [cherryRaw, oursRaw, theirsRaw] = await Promise.all([
+        this.git.raw(['cherry', 'HEAD', upstream]).catch(() => ''),
+        this.git.raw(['log', '--format=%s', `${upstream}..HEAD`]).catch(() => ''),
+        this.git.raw(['log', '--format=%s', `HEAD..${upstream}`]).catch(() => ''),
+      ]);
+      const cherry = cherryRaw.trim().split('\n').map(l => l.trim()).filter(Boolean);
+      if (cherry.length > 0 && cherry.every(l => l.startsWith('-'))) return true;
+      const ours = new Set(oursRaw.split('\n').map(l => l.trim()).filter(Boolean));
+      const theirs = theirsRaw.split('\n').map(l => l.trim()).filter(Boolean);
+      return theirs.length > 0 && theirs.every(subject => ours.has(subject));
+    } catch {
+      return false;
+    }
+  }
+
   async push(force = false, remote?: string): Promise<void> {
     const vsRepo = this.vsRepo();
     // Only use VS Code API when it actually knows the remotes for this repo.

--- a/src/host/panels/CommitPanelProvider.ts
+++ b/src/host/panels/CommitPanelProvider.ts
@@ -21,10 +21,46 @@ import { pickRefQuickPick } from '../utils/refPicker';
 import type { GitProfileService } from '../git/GitProfileService';
 import { LOCAL_PROFILE_ID, GLOBAL_PROFILE_ID } from '../git/GitProfileService';
 import type { BranchStatusBar } from '../ui/BranchStatusBar';
-import { formatGitError, showGitError, getRawErrorDetail } from '../utils/gitErrorUtils';
+import { formatGitError, showGitError, getRawErrorDetail, isPushRejected } from '../utils/gitErrorUtils';
 import { logInfo, logWarn, logError, showLogChannel } from '../utils/Logger';
 import { ViewAndSortSettingsService } from '../settings/ViewAndSortSettingsService';
 import type { ViewAndSortSettings } from '../types/settings';
+
+type DivergedStrategy = 'merge' | 'rebase' | 'force';
+
+/**
+ * Asks — in the command bar — how to reconcile branches that have diverged from their
+ * upstream. When the divergence looks like rewritten history (amend, rebase, squash) the
+ * force option leads, since that is almost always what the user meant to do.
+ */
+async function promptDivergedStrategy(repoNames: string[], rewritten: boolean): Promise<DivergedStrategy | undefined> {
+  const merge = {
+    label: '$(git-merge) Pull, then Push',
+    description: 'Merge the incoming commits into your branch',
+    strategy: 'merge' as const,
+  };
+  const rebase = {
+    label: '$(repo-forked) Pull (Rebase), then Push',
+    description: 'Replay your commits on top of the incoming ones',
+    strategy: 'rebase' as const,
+  };
+  const force = {
+    label: '$(repo-force-push) Force Push',
+    description: 'Overwrite the remote branch with your local history (--force-with-lease)',
+    strategy: 'force' as const,
+  };
+  const names = repoNames.join(', ');
+  const pick = await vscode.window.showQuickPick(
+    rewritten ? [force, rebase, merge] : [merge, rebase, force],
+    {
+      title: rewritten
+        ? `${names}: local history was rewritten and no longer matches the remote`
+        : `${names}: your branch and the remote have both moved on`,
+      placeHolder: 'Choose how to reconcile before syncing',
+    }
+  );
+  return pick?.strategy;
+}
 
 export class CommitPanelProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'gitcharm.commitPanel';
@@ -809,6 +845,94 @@ export class CommitPanelProvider implements vscode.WebviewViewProvider {
             }
           }
         );
+        break;
+      }
+
+      case 'COMMIT_SYNC_REPOS': {
+        const metas = this.manager.getRepoMetas();
+        const nameOf = (repoId: string) => metas.find(m => m.id === repoId)?.name ?? repoId;
+        const targets = msg.repoIds
+          .map(repoId => ({ repoId, repo: this.manager.getRepo(repoId) }))
+          .filter((t): t is { repoId: string; repo: NonNullable<typeof t.repo> } => !!t.repo);
+        if (targets.length === 0) {
+          logWarn('sync', 'Repo not found');
+          this.post({ type: 'COMMIT_OP_RESULT', requestId: msg.requestId, ok: false, error: 'Repo not found' });
+          break;
+        }
+
+        const states = await Promise.all(targets.map(async t => ({ ...t, state: await t.repo.getUpstreamState() })));
+        const diverged = states.filter(s => s.state.ahead > 0 && s.state.behind > 0);
+
+        // A diverged branch can't be reconciled without the user's call — merge, rebase, or
+        // overwrite the remote. Ask once for the whole batch, up in the command bar.
+        let strategy: DivergedStrategy | undefined;
+        if (diverged.length > 0) {
+          strategy = await promptDivergedStrategy(
+            diverged.map(d => nameOf(d.repoId)),
+            diverged.some(d => d.state.rewritten),
+          );
+          if (!strategy) {
+            this.post({ type: 'COMMIT_OP_RESULT', requestId: msg.requestId, ok: false, error: 'Cancelled' });
+            break;
+          }
+        }
+
+        const errors: string[] = [];
+        await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Notification, title: targets.length === 1 ? 'Syncing' : 'Syncing repositories', cancellable: false },
+          async () => {
+            for (const { repoId, repo, state } of states) {
+              const label = nameOf(repoId);
+              try {
+                if (!state.upstream) {
+                  // No upstream yet — push sets it up (publish).
+                  await repo.push();
+                } else if (state.ahead > 0 && state.behind > 0) {
+                  if (strategy === 'force') {
+                    await repo.push(true);
+                  } else {
+                    await (strategy === 'rebase' ? repo.pullRebase() : repo.pull());
+                    await repo.push();
+                  }
+                } else if (state.behind > 0) {
+                  await repo.pull();
+                } else if (state.ahead > 0) {
+                  try {
+                    await repo.push();
+                  } catch (e: unknown) {
+                    // The remote moved between our status read and the push — same choice as above.
+                    if (!isPushRejected(e)) throw e;
+                    logWarn('sync', `${label}: push rejected — asking how to reconcile`);
+                    const fallback = await promptDivergedStrategy([label], false);
+                    if (!fallback) { errors.push(`${label}: Cancelled`); continue; }
+                    if (fallback === 'force') {
+                      await repo.push(true);
+                    } else {
+                      await (fallback === 'rebase' ? repo.pullRebase() : repo.pull());
+                      await repo.push();
+                    }
+                  }
+                }
+                logInfo('sync', `Synced ${repoId}`);
+              } catch (e: unknown) {
+                logError(`sync:${repoId}`, formatGitError(e), getRawErrorDetail(e));
+                errors.push(`${label}: ${formatGitError(e)}`);
+              }
+            }
+          }
+        );
+
+        if (errors.length > 0) {
+          this.post({ type: 'COMMIT_OP_RESULT', requestId: msg.requestId, ok: false, error: errors.join('\n') });
+          void vscode.window.showWarningMessage(`Sync failed — ${errors.join('; ')}`, 'Show Log').then(choice => {
+            if (choice === 'Show Log') showLogChannel();
+          });
+        } else {
+          this.post({ type: 'COMMIT_OP_RESULT', requestId: msg.requestId, ok: true });
+        }
+        this.logProvider?.refresh();
+        const syncStatus = await this.manager.getAllStatusesFresh();
+        this.post({ type: 'COMMIT_STATUS_UPDATE', repos: this.manager.getRepoMetas(), status: syncStatus });
         break;
       }
 

--- a/src/host/types/messages.ts
+++ b/src/host/types/messages.ts
@@ -110,6 +110,7 @@ export type CommitToHostMsg =
   | { type: 'OPEN_PROFILES_MENU' }
   | { type: 'COMMIT_PUSH_REPO'; requestId: string; repoId: string; remote: string; force?: boolean }
   | { type: 'COMMIT_SYNC_AND_PUSH_REPO'; requestId: string; repoId: string; rebase: boolean }
+  | { type: 'COMMIT_SYNC_REPOS'; requestId: string; repoIds: string[] }
   | { type: 'COMMIT_DISCARD_FILE'; requestId: string; repoId: string; path: string }
   | { type: 'COMMIT_DISCARD_FILES'; requestId: string; files: Array<{ repoId: string; path: string }> }
   | { type: 'COMMIT_DISCARD_ALL'; requestId: string; repoId: string }

--- a/src/host/utils/gitErrorUtils.ts
+++ b/src/host/utils/gitErrorUtils.ts
@@ -81,6 +81,22 @@ export function formatGitError(e: unknown, maxLines = 3): string {
   return capitalizeFirst(String(e));
 }
 
+/**
+ * True when a push failed because the remote has commits we don't have — the case where
+ * the user has to choose between pulling first and overwriting the remote branch.
+ */
+export function isPushRejected(e: unknown): boolean {
+  if (!(e instanceof Error) && typeof e !== 'object') return false;
+  const err = e as { gitErrorCode?: string; stderr?: string; stdout?: string; message?: string };
+  const code = err.gitErrorCode as GitErrorCodes | undefined;
+  if (code === GitErrorCodes.PushRejected
+    || code === GitErrorCodes.ForcePushWithLeaseRejected
+    || code === GitErrorCodes.ForcePushWithLeaseIfIncludesRejected) return true;
+  // simple-git doesn't set gitErrorCode — fall back to git's own wording.
+  const text = stripAnsi([err.stderr, err.stdout, err.message].filter(Boolean).join('\n'));
+  return /\(non-fast-forward\)|\(fetch first\)|\(stale info\)|failed to push some refs/i.test(text);
+}
+
 /** Full, untruncated error detail (stderr/stdout/message) for the output log. */
 export function getRawErrorDetail(e: unknown): string | undefined {
   if (!(e instanceof Error) && typeof e !== 'object') return undefined;

--- a/src/webview/commitPanel/components/UnifiedCommitForm.tsx
+++ b/src/webview/commitPanel/components/UnifiedCommitForm.tsx
@@ -2,10 +2,16 @@ import React, { useEffect, useRef, useState } from 'react';
 import type { RepoMeta, RepoStatus } from '../../shared/types';
 import { Codicon } from '../../shared/Codicon';
 import { AuthorAvatar } from '../../shared/AuthorAvatar';
+import { computeSyncState, hasWorkingChanges, type SyncAction } from '../syncState';
 
 interface Props {
   message: string;
   repoStatuses: RepoStatus[];
+  /**
+   * Every repo visible in the panel, including ones with no changes — the commit tab can
+   * hide unchanged repos, but publish/sync still has to work for them.
+   */
+  syncRepoStatuses?: RepoStatus[];
   repoMetas: RepoMeta[];
   amendFlags: Record<string, boolean>;
   loading: boolean;
@@ -23,6 +29,10 @@ interface Props {
   onStash: () => void;
   onPush: (repoId: string) => void;
   onPushAll: () => void;
+  onSyncAction: (action: SyncAction, repoIds: string[]) => void;
+  onPullRepos: (repoIds: string[]) => void;
+  onPushRepos: (repoIds: string[]) => void;
+  onForcePushRepos: (repoIds: string[]) => void;
   aiEnabled: boolean;
   onAutopilot: () => void;
   onAutopilotContextMenu: (e: React.MouseEvent) => void;
@@ -35,7 +45,7 @@ interface DropdownButtonItem { icon: string; label: string; onSelect: () => void
 interface DropdownButtonProps {
   enabled: boolean;
   icon: string;
-  label: string;
+  label: React.ReactNode;
   title?: string;
   disabledTitle?: string;
   variant: 'primary' | 'secondary';
@@ -106,7 +116,7 @@ function DropdownButton({ enabled, icon, label, title, disabledTitle, variant, f
         <button
           style={{ ...childStyle, flex: fullWidth ? 1 : undefined, gap: '6px', padding: '5px 12px', backgroundColor: hoverMain && enabled ? bgHover : bg }}
           disabled={!enabled}
-          title={enabled ? (title ?? label) : (disabledTitle ?? '')}
+          title={enabled ? (title ?? (typeof label === 'string' ? label : undefined)) : (disabledTitle ?? '')}
           onClick={() => { if (enabled) onMainClick(); }}
           onMouseEnter={() => setHoverMain(true)}
           onMouseLeave={() => setHoverMain(false)}
@@ -114,19 +124,21 @@ function DropdownButton({ enabled, icon, label, title, disabledTitle, variant, f
           <Codicon name={icon} style={{ fontSize: '14px', flexShrink: 0 }} />
           <span>{label}</span>
         </button>
-        <div style={{ width: '1px', alignSelf: 'stretch', padding: '4px 0', flexShrink: 0, display: 'flex', backgroundColor: 'inherit' }}>
-          <div style={{ flex: 1, backgroundColor: variant === 'primary' ? 'var(--vscode-button-foreground)' : 'var(--vscode-button-secondaryForeground, var(--vscode-foreground))', opacity: 0.3 }} />
-        </div>
-        <button
-          style={{ ...childStyle, padding: '5px 7px', backgroundColor: hoverChevron && enabled ? bgHover : bg }}
-          disabled={!enabled}
-          title="More Actions..."
-          onClick={() => { if (enabled) setOpen(o => !o); }}
-          onMouseEnter={() => setHoverChevron(true)}
-          onMouseLeave={() => setHoverChevron(false)}
-        >
-          <Codicon name="chevron-down" style={{ fontSize: '12px' }} />
-        </button>
+        {items.length > 0 && (<>
+          <div style={{ width: '1px', alignSelf: 'stretch', padding: '4px 0', flexShrink: 0, display: 'flex', backgroundColor: 'inherit' }}>
+            <div style={{ flex: 1, backgroundColor: variant === 'primary' ? 'var(--vscode-button-foreground)' : 'var(--vscode-button-secondaryForeground, var(--vscode-foreground))', opacity: 0.3 }} />
+          </div>
+          <button
+            style={{ ...childStyle, padding: '5px 7px', backgroundColor: hoverChevron && enabled ? bgHover : bg }}
+            disabled={!enabled}
+            title="More Actions..."
+            onClick={() => { if (enabled) setOpen(o => !o); }}
+            onMouseEnter={() => setHoverChevron(true)}
+            onMouseLeave={() => setHoverChevron(false)}
+          >
+            <Codicon name="chevron-down" style={{ fontSize: '12px' }} />
+          </button>
+        </>)}
       </div>
       {open && (
         <div style={{
@@ -161,9 +173,34 @@ function DropItem({ icon, label, itemStyle, onSelect }: { icon: string; label: s
   );
 }
 
+function syncTitle(action: SyncAction, ahead: number, behind: number): string {
+  if (action === 'publish') return 'Push this branch to the remote and start tracking it';
+  const parts: string[] = [];
+  if (behind > 0) parts.push(`pull ${behind} commit${behind === 1 ? '' : 's'}`);
+  if (ahead > 0) parts.push(`push ${ahead} commit${ahead === 1 ? '' : 's'}`);
+  return `Sync Changes — ${parts.join(' and ')}`;
+}
+
+function syncDropdownItems(
+  action: SyncAction,
+  repoIds: string[],
+  onPullRepos: (repoIds: string[]) => void,
+  onPushRepos: (repoIds: string[]) => void,
+  onForcePushRepos: (repoIds: string[]) => void,
+): DropdownButtonItem[] {
+  // Publishing has no alternative worth offering — the branch is not on the remote yet.
+  if (action === 'publish' || action === 'none') return [];
+  const pull: DropdownButtonItem = { icon: 'arrow-down', label: 'Pull', onSelect: () => onPullRepos(repoIds) };
+  const push: DropdownButtonItem = { icon: 'arrow-up', label: 'Push', onSelect: () => onPushRepos(repoIds) };
+  const forcePush: DropdownButtonItem = { icon: 'repo-force-push', label: 'Force Push', onSelect: () => onForcePushRepos(repoIds) };
+  if (action === 'pull') return [pull, push, forcePush];
+  return [push, pull, forcePush];
+}
+
 export function UnifiedCommitForm({
-  message, repoStatuses, repoMetas, amendFlags,
+  message, repoStatuses, syncRepoStatuses, repoMetas, amendFlags,
   loading, changesViewMode, defaultCommitAction = 'commit', defaultSaveAction = 'stash', vscodeSelectedRepos, getSelectedFilesForRepo, onDeselectRepo, onMessageChange, onAmendToggle, onCommit, onCommitAndPush, onShelve, onStash,
+  onSyncAction, onPullRepos, onPushRepos, onForcePushRepos,
   aiEnabled, onAutopilot, onAutopilotContextMenu, generatingMessage,
   activeProfile, onOpenProfiles,
 }: Props) {
@@ -180,6 +217,12 @@ export function UnifiedCommitForm({
 
   const canCommit = message.trim().length > 0 && commitTargets.length > 0 && !loading;
   const multiRepo = repoStatuses.length > 1;
+
+  // With nothing to commit the primary button turns into the remote action the branch
+  // actually needs, so publishing or syncing no longer means switching to the Push tab.
+  const syncRepos = syncRepoStatuses ?? repoStatuses;
+  const sync = computeSyncState(syncRepos);
+  const showSync = !hasWorkingChanges(syncRepos) && sync.action !== 'none' && !loading;
 
   const amendTarget = commitTargets.length === 1 ? commitTargets[0] : null;
   const showAmend = amendTarget !== null && (amendTarget.branch.aheadBehind?.ahead ?? 0) > 0;
@@ -415,6 +458,33 @@ export function UnifiedCommitForm({
         </div>
 
         <div style={styles.rightActions}>
+          {showSync ? (
+            <DropdownButton
+              variant="primary"
+              fullWidth
+              dropdownAlign="right"
+              enabled
+              icon={sync.icon}
+              label={
+                <span style={styles.syncLabel}>
+                  {sync.label}
+                  {sync.behind > 0 && (
+                    <span style={styles.syncCount}>
+                      {sync.behind}<Codicon name="arrow-down" style={styles.syncArrow} />
+                    </span>
+                  )}
+                  {sync.ahead > 0 && (
+                    <span style={styles.syncCount}>
+                      {sync.ahead}<Codicon name="arrow-up" style={styles.syncArrow} />
+                    </span>
+                  )}
+                </span>
+              }
+              title={syncTitle(sync.action, sync.ahead, sync.behind)}
+              items={syncDropdownItems(sync.action, sync.repoIds, onPullRepos, onPushRepos, onForcePushRepos)}
+              onMainClick={() => onSyncAction(sync.action, sync.repoIds)}
+            />
+          ) : (
           <DropdownButton
             variant="primary"
             fullWidth
@@ -436,6 +506,7 @@ export function UnifiedCommitForm({
             }
             onMainClick={defaultCommitAction === 'commitAndPush' ? onCommitAndPush : onCommit}
           />
+          )}
         </div>
       </div>
 
@@ -589,6 +660,20 @@ const styles = {
   rightActions: {
     flex: 1,
     minWidth: 0,
+  } as React.CSSProperties,
+  syncLabel: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+  } as React.CSSProperties,
+  syncCount: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '1px',
+    fontVariantNumeric: 'tabular-nums',
+  } as React.CSSProperties,
+  syncArrow: {
+    fontSize: '11px',
   } as React.CSSProperties,
   stashBtn: {
     display: 'flex',

--- a/src/webview/commitPanel/main.tsx
+++ b/src/webview/commitPanel/main.tsx
@@ -5,6 +5,7 @@ import { ProjectGroup } from './components/ProjectGroup';
 import { ChangelistView } from './components/ChangelistView';
 import { VscodeView } from './components/VscodeView';
 import { UnifiedCommitForm } from './components/UnifiedCommitForm';
+import type { SyncAction } from './syncState';
 import { ContextMenu, type ContextMenuEntry } from './components/ContextMenu';
 import { ShelvePanel } from './components/ShelvePanel';
 import { StashTab } from './components/StashTab';
@@ -972,6 +973,30 @@ function App() {
     send({ type: 'COMMIT_SYNC_AND_PUSH_REPO', requestId: generateId(), repoId, rebase: false });
   };
 
+  const doPull = (repoId: string) => {
+    send({ type: 'COMMIT_PULL_REPO', requestId: generateId(), repoId });
+  };
+
+  // Commit-tab publish/sync button. Publish and the explicit dropdown entries map straight
+  // onto push/pull; 'sync' goes to the host, which works out whether a plain pull is enough
+  // or the divergence needs a rebase/force decision from the user.
+  const doSyncAction = (action: SyncAction, repoIds: string[]) => {
+    switch (action) {
+      case 'publish':
+      case 'push':
+        repoIds.forEach(doPush);
+        break;
+      case 'pull':
+        repoIds.forEach(doPull);
+        break;
+      case 'sync':
+        send({ type: 'COMMIT_SYNC_REPOS', requestId: generateId(), repoIds } satisfies CommitToHostMsg);
+        break;
+      case 'none':
+        break;
+    }
+  };
+
   // ── Autopilot ─────────────────────────────────────────────────────────────
 
   const doAutopilot = useCallback(() => {
@@ -1448,6 +1473,11 @@ function App() {
             onCommitAndPush={() => doCommit(true)}
             onPush={doPush}
             onPushAll={doPushAll}
+            syncRepoStatuses={repos}
+            onSyncAction={doSyncAction}
+            onPullRepos={ids => ids.forEach(doPull)}
+            onPushRepos={ids => ids.forEach(doPush)}
+            onForcePushRepos={ids => ids.forEach(doForcePush)}
             aiEnabled={store.aiEnabled}
             onAutopilot={doAutopilot}
             onAutopilotContextMenu={doAutopilotContextMenu}

--- a/src/webview/commitPanel/syncState.ts
+++ b/src/webview/commitPanel/syncState.ts
@@ -1,0 +1,73 @@
+import type { RepoStatus } from '../shared/types';
+
+/**
+ * What the primary button in the commit tab should do when there is nothing to commit.
+ *
+ * - `publish` — at least one branch has no upstream yet
+ * - `push` / `pull` — published branches that are only ahead / only behind
+ * - `sync`   — published branches that are both ahead and behind (diverged, e.g. after an amend)
+ * - `none`   — nothing to publish, push or pull
+ */
+export type SyncAction = 'publish' | 'push' | 'pull' | 'sync' | 'none';
+
+export interface SyncState {
+  action: SyncAction;
+  /** Commits to push, summed across the repos the action applies to. */
+  ahead: number;
+  /** Commits to pull, summed across the repos the action applies to. */
+  behind: number;
+  /** Repos the action applies to. */
+  repoIds: string[];
+  label: string;
+  icon: string;
+}
+
+const NONE: SyncState = { action: 'none', ahead: 0, behind: 0, repoIds: [], label: 'Sync Changes', icon: 'sync' };
+
+/**
+ * Derives the publish/sync state for the commit tab from the repos it shows.
+ *
+ * Publishing wins over syncing: an unpublished branch has no upstream to compare against,
+ * so it has to reach the remote before ahead/behind means anything.
+ */
+export function computeSyncState(repos: RepoStatus[]): SyncState {
+  // A detached HEAD has no branch to publish or track.
+  const eligible = repos.filter(r => !r.isDetachedHead);
+  if (eligible.length === 0) return NONE;
+
+  const unpublished = eligible.filter(r => !r.branch.upstream);
+  if (unpublished.length > 0) {
+    return {
+      action: 'publish',
+      ahead: 0,
+      behind: 0,
+      repoIds: unpublished.map(r => r.repoId),
+      label: unpublished.length === 1 ? 'Publish Branch' : `Publish ${unpublished.length} Branches`,
+      icon: 'cloud-upload',
+    };
+  }
+
+  const outOfSync = eligible.filter(r => (r.branch.aheadBehind?.ahead ?? 0) > 0 || (r.branch.aheadBehind?.behind ?? 0) > 0);
+  if (outOfSync.length === 0) return NONE;
+
+  let ahead = 0;
+  let behind = 0;
+  for (const r of outOfSync) {
+    ahead += r.branch.aheadBehind?.ahead ?? 0;
+    behind += r.branch.aheadBehind?.behind ?? 0;
+  }
+
+  return {
+    action: ahead > 0 && behind > 0 ? 'sync' : ahead > 0 ? 'push' : 'pull',
+    ahead,
+    behind,
+    repoIds: outOfSync.map(r => r.repoId),
+    label: 'Sync Changes',
+    icon: 'sync',
+  };
+}
+
+/** True when any of the given repos has uncommitted work (staged or not). */
+export function hasWorkingChanges(repos: RepoStatus[]): boolean {
+  return repos.some(r => r.stagedFiles.length > 0 || r.unstagedFiles.length > 0);
+}


### PR DESCRIPTION
The commit tab's primary button stayed a disabled "Commit" once the working tree was clean, so publishing a branch or pushing/pulling commits meant switching to the Push tab. Now the button becomes the action the branch actually needs:

- working-tree changes  -> Commit / Commit & Push (unchanged)
- no upstream           -> Publish Branch
- ahead and/or behind   -> Sync Changes, with counts and up/down arrows

Sync state is computed from every visible repo rather than the changes-tab list, which "hide repos without changes" empties exactly when the sync button is needed.

Sync routes through a new COMMIT_SYNC_REPOS host message that decides push/pull/publish per repo. A diverged branch cannot be reconciled without the user, so it prompts in the command bar for merge, rebase, or force push with lease; the same prompt appears when a push is rejected mid-flight. When the divergence looks like rewritten history (amend, rebase, squash) the force option is listed first, detected via patch equivalence (git cherry) and matching commit subjects.