### PR TITLE
perf(log): keep rows on screen across refreshes, preserve scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -804,7 +804,7 @@
             "default": 1000,
             "minimum": 100,
             "maximum": 10000,
-            "description": "Maximum commits to load in the Git Log graph"
+            "description": "Maximum commits to load in the Git Log graph. Scrolling stops paging in more once this many are loaded."
           },
           "gitcharm.repositoryScanMaxDepth": {
             "order": 60,

--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -480,7 +480,11 @@ export class GitService {
     const isHashSearch = opts?.filterText && /^[0-9a-f]{4,40}$/i.test(opts.filterText.trim());
     const args: string[] = [
       'log',
-      '--topo-order',
+      // --date-order, not --topo-order: the log renders in committer-date order (see
+      // getInterleavedLog), and asking git for a different order than the one displayed
+      // meant a page's contents depended on where its boundaries fell. Date order is
+      // still topological — a commit never precedes its own parent.
+      '--date-order',
       // Hash search scans the full history without pagination — result is always a single commit
       ...(isHashSearch ? ['--max-count=50000'] : [`--max-count=${limit}`, `--skip=${skip}`]),
       '--format=%H%x00%h%x00%P%x00%an%x00%ae%x00%ai%x00%ci%x00%D%x00%s', '--decorate=full',

--- a/src/host/panels/GitLogPanelProvider.ts
+++ b/src/host/panels/GitLogPanelProvider.ts
@@ -321,8 +321,13 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
   private async handleMessage(msg: LogToHostMsg): Promise<void> {
     switch (msg.type) {
       case 'LOG_REQUEST_COMMITS': {
+        // graphMaxCommits is a ceiling on how many commits the graph holds, not a page
+        // size: pagination adds to what is already loaded, so the cap belongs on
+        // skip + limit. Capping the page size alone let a deep scroll grow the list past
+        // the ceiling, and the next refresh — one request covering every loaded row — came
+        // back truncated, dropping rows out from under the viewport.
         const maxCommits = vscode.workspace.getConfiguration('gitcharm').get<number>('graphMaxCommits', 1000);
-        const limit = Math.min(msg.limit, maxCommits);
+        const limit = Math.min(msg.limit, Math.max(0, maxCommits - msg.skip));
 
         const repos = this.getVisibleRepos();
         const [branches, iconTheme] = await Promise.all([
@@ -343,14 +348,19 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
         const logRepoIds = msg.repoIds.length > 0
           ? msg.repoIds.filter(id => !this.manager.getRepoMetas().find(m => m.id === id)?.isWorktree && !this.hiddenRepoIds.includes(id))
           : this.getVisibleRepos().map(r => r.id);
-        const commits = await this.manager.getInterleavedLog(logRepoIds, limit, msg.skip, {
-          filterText: msg.filterText,
-          filterAuthor: msg.filterAuthor,
-          filterBranch: msg.filterBranch,
-          filterDateFrom: msg.filterDateFrom,
-          filterDateTo: msg.filterDateTo,
-        });
-        this.post({ type: 'LOG_COMMITS_BATCH', commits, isLast: commits.length < limit, batchIndex: 0, requestId: msg.requestId });
+        const commits = limit > 0
+          ? await this.manager.getInterleavedLog(logRepoIds, limit, msg.skip, {
+            filterText: msg.filterText,
+            filterAuthor: msg.filterAuthor,
+            filterBranch: msg.filterBranch,
+            filterDateFrom: msg.filterDateFrom,
+            filterDateTo: msg.filterDateTo,
+          })
+          : [];
+        // Last batch when git ran out of commits, or when the ceiling is reached — either
+        // way there is nothing further to page in, and the client stops asking.
+        const isLast = commits.length < limit || msg.skip + commits.length >= maxCommits;
+        this.post({ type: 'LOG_COMMITS_BATCH', commits, isLast, batchIndex: 0, requestId: msg.requestId });
 
         // Send stashes only on first load (not on pagination)
         if (msg.skip === 0) {

--- a/src/webview/gitLog/components/CommitList.tsx
+++ b/src/webview/gitLog/components/CommitList.tsx
@@ -44,7 +44,6 @@ interface RepoBlock {
 
 const REPO_LABEL_WIDTH = 6;
 const REPO_LABEL_WIDTH_EXPANDED = 110;
-const BLOCK_GAP = 4;
 
 function generateId() {
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
@@ -77,6 +76,67 @@ function CommitSkeleton() {
     </div>
   );
 }
+
+export interface ScrollAnchor {
+  /** Index the anchor commit occupied in `list`. */
+  index: number;
+  hash: string;
+  /** Pixels the anchor row was scrolled past, i.e. scrollTop - index * ROW_HEIGHT. */
+  offset: number;
+  /** The array the anchor was captured from, for walking to predecessors. */
+  list: ReadonlyArray<{ hash: string }>;
+}
+
+/**
+ * Work out where a captured scroll anchor lives in a freshly swapped-in commit
+ * list, so the viewport can be put back over the same commit.
+ *
+ * Returns null when no scrolling is needed — which is the common case, and is
+ * reached in O(1).
+ *
+ * Ordered by how often each case actually happens:
+ *  1. Same array, or anchor still at its old index (every append, and every
+ *     refresh that changed nothing above the viewport) — no work.
+ *  2. Anchor shifted a little, because a few commits arrived at the top —
+ *     found by probing outward from the old index.
+ *  3. Anchor shifted a lot, or vanished (amend, rebase, branch switch) — one
+ *     hash->index map, then the anchor, then its predecessors walking toward
+ *     HEAD, so the user stays in the same neighbourhood of history.
+ *  4. Nothing that was on screen survived — go to the top.
+ */
+export function resolveAnchor(
+  a: ScrollAnchor,
+  commits: ReadonlyArray<{ hash: string }>,
+): { index: number; offset: number } | null {
+  if (commits.length === 0) return null;
+  if (a.list === commits) return null;
+  if (commits[a.index]?.hash === a.hash) return null;
+
+  for (let d = 1; d <= ANCHOR_PROBE; d++) {
+    if (commits[a.index + d]?.hash === a.hash) return { index: a.index + d, offset: a.offset };
+    if (commits[a.index - d]?.hash === a.hash) return { index: a.index - d, offset: a.offset };
+  }
+
+  const pos = new Map<string, number>();
+  for (let i = 0; i < commits.length; i++) pos.set(commits[i].hash, i);
+
+  const found = pos.get(a.hash);
+  if (found !== undefined) return { index: found, offset: a.offset };
+
+  for (let i = a.index - 1; i >= 0; i--) {
+    const p = pos.get(a.list[i].hash);
+    if (p !== undefined) return { index: p, offset: a.offset };
+  }
+
+  return { index: 0, offset: 0 };
+}
+
+/**
+ * How far to probe either side of the old index before falling back to a map.
+ * A refresh normally only prepends the commits that landed since the last one,
+ * so the anchor is almost always within a row or two of where it was.
+ */
+const ANCHOR_PROBE = 32;
 
 const SKELETON_MIN_MS = 400;
 
@@ -165,11 +225,13 @@ export function CommitList({ layout, selectedHash, repoColors, repos, activeRepo
   }, [commits, repoMeta, multiRepo]);
 
 
-  // Last index of each block — the gap is added after these rows.
-  const blockLastIndex = useMemo(() => {
+  // First index of each repo block (except the very first) — these rows draw a
+  // separator line. It's an inset shadow, not a border or a gap, so it costs no
+  // layout height and every row stays exactly ROW_HEIGHT tall.
+  const blockStartIndex = useMemo(() => {
     const s = new Set<number>();
     for (const block of repoBlocks) {
-      if (block.startRow > 0) s.add(block.startRow - 1);
+      if (block.startRow > 0) s.add(block.startRow);
     }
     return s;
   }, [repoBlocks]);
@@ -177,16 +239,14 @@ export function CommitList({ layout, selectedHash, repoColors, repos, activeRepo
   const virtualizer = useVirtualizer({
     count: commits.length,
     getScrollElement: () => parentRef.current,
-    // Tell the virtualizer the true height of each row, including the gap
-    // that follows the last row of each block.
-    estimateSize: (i) => ROW_HEIGHT + (multiRepo && blockLastIndex.has(i) ? BLOCK_GAP : 0),
+    // Every row is exactly ROW_HEIGHT. This is load-bearing, not just a hint:
+    // it makes index <-> pixel an exact multiplication, which is what lets
+    // scroll anchoring below restore a position without measuring anything.
+    estimateSize: () => ROW_HEIGHT,
     overscan: 10,
   });
 
-  const rawItems = virtualizer.getVirtualItems();
-  // Use the virtualizer's own start positions — they already account for the
-  // variable sizes above, so no manual offset calculation is needed.
-  const items = rawItems;
+  const items = virtualizer.getVirtualItems();
 
   const hasMoreRef = useRef(hasMore);
   hasMoreRef.current = hasMore;
@@ -194,6 +254,24 @@ export function CommitList({ layout, selectedHash, repoColors, repos, activeRepo
   onLoadMoreRef.current = onLoadMore;
 
   const scrollRafRef = useRef<number | null>(null);
+
+  // Scroll anchor: which commit sits at the top of the viewport, and by how many
+  // pixels it is scrolled past. Captured continuously as the user scrolls (one
+  // array index + two subtractions per animation frame) so that when the list is
+  // swapped out by a refresh, the restore below needs no cooperation from the
+  // store, no signalling, and no ordering assumptions — the anchor is simply
+  // always current. `list` is a reference to the array the anchor was taken
+  // from, kept so a vanished anchor can walk back to its predecessors.
+  const anchorRef = useRef<ScrollAnchor | null>(null);
+  const commitsRef = useRef(commits);
+  commitsRef.current = commits;
+
+  const captureAnchor = useCallback((scrollTop: number) => {
+    const list = commitsRef.current;
+    if (list.length === 0) { anchorRef.current = null; return; }
+    const index = Math.max(0, Math.min(list.length - 1, Math.floor(scrollTop / ROW_HEIGHT)));
+    anchorRef.current = { index, hash: list[index].hash, offset: scrollTop - index * ROW_HEIGHT, list };
+  }, []);
 
   // Attach scroll listener once via callback ref — avoids dependency on parentRef timing
   const scrollListenerRef = useRef<(() => void) | null>(null);
@@ -215,36 +293,68 @@ export function CommitList({ layout, selectedHash, repoColors, repos, activeRepo
       if (scrollRafRef.current !== null) return;
       scrollRafRef.current = requestAnimationFrame(() => {
         scrollRafRef.current = null;
+        captureAnchor(el.scrollTop);
         const nearBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - ROW_HEIGHT * 15;
         if (hasMoreRef.current && nearBottom) onLoadMoreRef.current();
       });
     };
     scrollListenerRef.current = listener;
     el.addEventListener('scroll', listener, { passive: true });
-  }, []);
+  }, [captureAnchor]);
+
+  const scrollToIndexExact = useCallback((index: number, offset: number) => {
+    const el = parentRef.current;
+    if (!el) return;
+    el.scrollTop = Math.max(0, index * ROW_HEIGHT + offset);
+    // Read back rather than reusing the requested value: the browser clamps at
+    // both ends, and `offset` may be negative when centring a row. Re-capturing
+    // from the real scrollTop keeps the anchor normalised (offset always within
+    // one row) so a later restore can't derive an out-of-range index.
+    captureAnchor(el.scrollTop);
+  }, [captureAnchor]);
+
+  // Restore the scroll anchor whenever the commit array is replaced under us.
+  //
+  // A layout effect, so it lands before the browser paints — the swap is never
+  // visible as a jump. Appends hit the O(1) early-out on the first check: the
+  // list only grew at the tail, so the anchor row is still at its old index and
+  // there is nothing to do. Only a genuine reshuffle pays for a lookup.
+  //
+  // Runs before the scrollToHash effect below (layout effects precede passive
+  // ones), which is the precedence we want: an explicit navigation request from
+  // the host always overrides a passive anchor restore.
+  useLayoutEffect(() => {
+    const a = anchorRef.current;
+    if (!a || !parentRef.current) return;
+    const resolved = resolveAnchor(a, commits);
+    if (resolved) {
+      scrollToIndexExact(resolved.index, resolved.offset);
+    } else if (a.list !== commits && commits.length > 0) {
+      // No scrolling needed, but re-point the anchor at the current array so the
+      // next swap short-circuits on identity and the old array can be collected.
+      a.list = commits;
+    }
+  }, [commits, scrollToIndexExact]);
 
   useEffect(() => {
     if (!scrollToHash) return;
     const idx = commits.findIndex(c => c.hash === scrollToHash);
     if (idx >= 0) {
-      virtualizer.scrollToIndex(idx, { align: 'center' });
+      // Centre the target row: exact arithmetic, since every row is ROW_HEIGHT.
+      const el = parentRef.current;
+      const centreOffset = el ? -Math.max(0, (el.clientHeight - ROW_HEIGHT) / 2) : 0;
+      scrollToIndexExact(idx, centreOffset);
       onSelect(commits[idx]);
       onScrolledToHash?.();
       return;
     }
     // Commit not yet in the loaded list — keep fetching batches until found or exhausted
     if (hasMore && !loading) onLoadMore();
-  }, [scrollToHash, commits, hasMore, loading]);
+  }, [scrollToHash, commits, hasMore, loading, scrollToIndexExact]);
 
   const anyExpanded = expandedRepos.size > 0;
   const labelColWidth = multiRepo ? (anyExpanded ? REPO_LABEL_WIDTH_EXPANDED + 6 : REPO_LABEL_WIDTH + 8) : 0;
 
-  // Map from commit index → virtualizer start position, for strip positioning.
-  const itemStartByIndex = useMemo(() => {
-    const map = new Map<number, number>();
-    for (const item of virtualizer.getVirtualItems()) map.set(item.index, item.start);
-    return map;
-  }, [virtualizer.getVirtualItems()]);
 
   function toggleRepo(repoId: string) {
     setExpandedRepos(prev => {
@@ -276,9 +386,8 @@ export function CommitList({ layout, selectedHash, repoColors, repos, activeRepo
 
         {/* Repo label strips */}
         {multiRepo && repoBlocks.map((block) => {
-          const topPx = itemStartByIndex.get(block.startRow) ?? block.startRow * ROW_HEIGHT;
-          const lastRowStart = itemStartByIndex.get(block.startRow + block.rowCount - 1) ?? ((block.startRow + block.rowCount - 1) * ROW_HEIGHT);
-          const heightPx = lastRowStart + ROW_HEIGHT - topPx;
+          const topPx = block.startRow * ROW_HEIGHT;
+          const heightPx = block.rowCount * ROW_HEIGHT;
           const expanded = expandedRepos.has(block.repoId);
           return (
             <div
@@ -320,7 +429,7 @@ export function CommitList({ layout, selectedHash, repoColors, repos, activeRepo
           return (
             <div
               key={commit.hash}
-              style={{ ...styles.row(vrow.start, isSelected, isMultiSelected, hoveredIndex === vrow.index, !isSelected && contextMenu?.commit.hash === commit.hash && contextMenu?.commit.repoId === commit.repoId), paddingLeft: textStart }}
+              style={{ ...styles.row(vrow.start, isSelected, isMultiSelected, hoveredIndex === vrow.index, !isSelected && contextMenu?.commit.hash === commit.hash && contextMenu?.commit.repoId === commit.repoId, multiRepo && blockStartIndex.has(vrow.index)), paddingLeft: textStart }}
               onMouseEnter={(e) => {
                 setHoveredIndex(vrow.index);
                 if (closePopoverTimerRef.current) clearTimeout(closePopoverTimerRef.current);
@@ -1582,7 +1691,7 @@ const styles = {
     textOverflow: 'ellipsis' as const,
     lineHeight: `${ROW_HEIGHT}px`,
   } as React.CSSProperties,
-  row: (top: number, selected: boolean, multiSelected = false, hovered = false, ctxActive = false): React.CSSProperties => ({
+  row: (top: number, selected: boolean, multiSelected = false, hovered = false, ctxActive = false, blockStart = false): React.CSSProperties => ({
     position: 'absolute' as const,
     top,
     left: 0,
@@ -1605,6 +1714,8 @@ const styles = {
       : 'var(--vscode-editor-background)',
     color: selected ? 'var(--vscode-list-activeSelectionForeground)' : 'var(--vscode-foreground)',
     fontSize: '12px',
+    // Repo-block separator: inset shadow keeps the row exactly ROW_HEIGHT tall.
+    ...(blockStart ? { boxShadow: 'inset 0 1px 0 var(--vscode-panel-border)' } : {}),
   }),
   refsMeasureRow: (labelColWidth: number): React.CSSProperties => ({
     position: 'absolute',

--- a/src/webview/gitLog/main.tsx
+++ b/src/webview/gitLog/main.tsx
@@ -140,7 +140,7 @@ function App() {
   }, []);
 
 
-  const sendAppendRequest = useCallback((f: import('./store/logStore').CommitFilters, skip: number, limit: number = PAGE_SIZE) => {
+  const sendAppendRequest = useCallback((f: import('./store/logStore').CommitFilters, limit: number = PAGE_SIZE) => {
     if (loadingInFlightRef.current) return;
     loadingInFlightRef.current = true;
     const reqId = generateId();
@@ -150,7 +150,7 @@ function App() {
       type: 'LOG_REQUEST_COMMITS',
       repoIds: f.repoId ? [f.repoId] : [],
       limit,
-      skip,
+      skip: 0,
       requestId: reqId,
       filterText: f.text || undefined,
       filterAuthor: f.author || undefined,
@@ -161,17 +161,23 @@ function App() {
     } satisfies LogToHostMsg);
   }, []);
 
+  // Paging asks for a longer prefix of the same traversal rather than the next slice
+  // after a --skip. Two things follow: the rows already on screen keep their order and
+  // their lanes, because the list only ever grows at the tail; and a refresh, which asks
+  // for that same prefix, gets back exactly what is displayed instead of a differently
+  // ordered list assembled from independently sorted pages.
   const loadMore = useCallback(() => {
     const s = useLogStore.getState();
     if (loadingInFlightRef.current || !s.hasMore) return;
-    sendAppendRequest(s.commitFilters, s.commits.length);
+    s.beginReload();
+    sendAppendRequest(s.commitFilters, s.commits.length + PAGE_SIZE);
   }, [sendAppendRequest]);
 
   const reloadCommits = useCallback((overrides?: Partial<import('./store/logStore').CommitFilters>) => {
     loadingInFlightRef.current = false;
     const f = { ...useLogStore.getState().commitFilters, ...overrides };
     useLogStore.getState().resetCommits();
-    sendAppendRequest(f, 0);
+    sendAppendRequest(f);
   }, [sendAppendRequest]);
 
   // Refresh triggered by a repo change (not by the user changing filters): keep the
@@ -190,7 +196,7 @@ function App() {
     // drop rows out from under the viewport.
     const limit = Math.ceil(s.commits.length / PAGE_SIZE) * PAGE_SIZE;
     s.beginReload();
-    sendAppendRequest(s.commitFilters, 0, limit);
+    sendAppendRequest(s.commitFilters, limit);
   }, [sendAppendRequest, reloadCommits]);
 
   // Keep reloadRef current so the message handler (mounted once) always calls the latest version

--- a/src/webview/gitLog/main.tsx
+++ b/src/webview/gitLog/main.tsx
@@ -18,6 +18,8 @@ function generateId() {
 }
 
 const LOAD_STEP = 150;
+// Upper bound on how many commits a warm refresh re-requests in one go.
+const REFRESH_LIMIT_MAX = 3000;
 
 
 function App() {
@@ -137,7 +139,7 @@ function App() {
   }, []);
 
 
-  const sendAppendRequest = useCallback((f: import('./store/logStore').CommitFilters, skip: number) => {
+  const sendAppendRequest = useCallback((f: import('./store/logStore').CommitFilters, skip: number, limit: number = LOAD_STEP) => {
     if (loadingInFlightRef.current) return;
     loadingInFlightRef.current = true;
     const reqId = generateId();
@@ -146,7 +148,7 @@ function App() {
     getVsCodeApi().postMessage({
       type: 'LOG_REQUEST_COMMITS',
       repoIds: f.repoId ? [f.repoId] : [],
-      limit: LOAD_STEP,
+      limit,
       skip,
       requestId: reqId,
       filterText: f.text || undefined,
@@ -171,8 +173,24 @@ function App() {
     sendAppendRequest(f, 0);
   }, [sendAppendRequest]);
 
+  // Refresh triggered by a repo change (not by the user changing filters): keep the
+  // existing rows visible and swap them for the fresh ones when they arrive, so the
+  // skeleton only ever appears on a cold start. Re-request as many commits as are
+  // currently loaded, so a deep-scrolled list doesn't shrink and jump under the user.
+  const refreshCommits = useCallback(() => {
+    loadingInFlightRef.current = false;
+    const s = useLogStore.getState();
+    if (s.commits.length === 0) {
+      reloadCommits();
+      return;
+    }
+    const limit = Math.min(REFRESH_LIMIT_MAX, Math.ceil(s.commits.length / LOAD_STEP) * LOAD_STEP);
+    s.beginReload();
+    sendAppendRequest(s.commitFilters, 0, limit);
+  }, [sendAppendRequest, reloadCommits]);
+
   // Keep reloadRef current so the message handler (mounted once) always calls the latest version
-  reloadRef.current = reloadCommits;
+  reloadRef.current = refreshCommits;
 
   const handleLoadMore = useCallback(() => {
     loadMore();

--- a/src/webview/gitLog/main.tsx
+++ b/src/webview/gitLog/main.tsx
@@ -17,9 +17,10 @@ function generateId() {
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
 }
 
-const LOAD_STEP = 150;
-// Upper bound on how many commits a warm refresh re-requests in one go.
-const REFRESH_LIMIT_MAX = 3000;
+// Commits per page. The ceiling on the graph as a whole is the host's
+// gitcharm.graphMaxCommits, which clamps every request and reports the last batch,
+// so there is nothing to bound here.
+const PAGE_SIZE = 150;
 
 
 function App() {
@@ -130,7 +131,7 @@ function App() {
     send({
       type: 'LOG_REQUEST_COMMITS',
       repoIds: [],
-      limit: LOAD_STEP,
+      limit: PAGE_SIZE,
       skip: 0,
       requestId: initReqId,
     });
@@ -139,7 +140,7 @@ function App() {
   }, []);
 
 
-  const sendAppendRequest = useCallback((f: import('./store/logStore').CommitFilters, skip: number, limit: number = LOAD_STEP) => {
+  const sendAppendRequest = useCallback((f: import('./store/logStore').CommitFilters, skip: number, limit: number = PAGE_SIZE) => {
     if (loadingInFlightRef.current) return;
     loadingInFlightRef.current = true;
     const reqId = generateId();
@@ -184,7 +185,10 @@ function App() {
       reloadCommits();
       return;
     }
-    const limit = Math.min(REFRESH_LIMIT_MAX, Math.ceil(s.commits.length / LOAD_STEP) * LOAD_STEP);
+    // Round up to whole pages. Asking for more than the ceiling allows is fine — the
+    // host clamps it — but asking for less than is loaded would truncate the list and
+    // drop rows out from under the viewport.
+    const limit = Math.ceil(s.commits.length / PAGE_SIZE) * PAGE_SIZE;
     s.beginReload();
     sendAppendRequest(s.commitFilters, 0, limit);
   }, [sendAppendRequest, reloadCommits]);

--- a/src/webview/gitLog/store/logStore.ts
+++ b/src/webview/gitLog/store/logStore.ts
@@ -19,6 +19,8 @@ interface LogState {
   iconTheme: IconThemeData | null;
   commits: CommitNode[];
   hasMore: boolean;
+  /** True between beginReload() and the first batch of the reload arriving. */
+  reloading: boolean;
   selectedCommit: CommitNode | null;
   selectedFile: { path: string; status: string } | null;
   commitFiles: Array<{ path: string; status: string; added?: number; removed?: number }>;
@@ -45,6 +47,7 @@ interface LogState {
   appendCommits: (commits: CommitNode[], isLast: boolean) => void;
   setCommits: (commits: CommitNode[], hasMore: boolean) => void;
   resetCommits: () => void;
+  beginReload: () => void;
   selectCommit: (commit: CommitNode | null) => void;
   setCommitFiles: (files: Array<{ path: string; status: string; added?: number; removed?: number }>) => void;
   selectFile: (file: { path: string; status: string } | null) => void;
@@ -71,6 +74,40 @@ const defaultCommitFilters: CommitFilters = {
   repoId: null,
 };
 
+/**
+ * Structural equality for two commit lists — everything a row renders from.
+ * Bails on the first difference, so an unchanged refresh costs O(n) cheap
+ * comparisons, and a changed one usually costs far less.
+ */
+function commitListsEqual(a: CommitNode[], b: CommitNode[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i], y = b[i];
+    if (x === y) continue;
+    if (
+      x.hash !== y.hash ||
+      x.repoId !== y.repoId ||
+      x.message !== y.message ||
+      x.committerDate !== y.committerDate ||
+      x.authorName !== y.authorName ||
+      x.authorEmail !== y.authorEmail ||
+      !!x.unpushed !== !!y.unpushed ||
+      !!x.incoming !== !!y.incoming ||
+      !stringsEqual(x.parents, y.parents) ||
+      !stringsEqual(x.refs, y.refs)
+    ) return false;
+  }
+  return true;
+}
+
+function stringsEqual(a: string[], b: string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
 export const useLogStore = create<LogState>((set, get) => ({
   repos: [],
   initialized: false,
@@ -82,6 +119,7 @@ export const useLogStore = create<LogState>((set, get) => ({
   commits: [],
   stashes: [],
   hasMore: true,
+  reloading: false,
   selectedCommit: null,
   selectedFile: null,
   commitFiles: [],
@@ -104,14 +142,41 @@ export const useLogStore = create<LogState>((set, get) => ({
     tags: [...s.tags.filter(t => t.repoId !== repoId), ...tags],
   })),
   setIconTheme: (iconTheme) => set({ iconTheme }),
-  appendCommits: (commits, isLast) => set(s => ({
-    commits: [...s.commits, ...commits],
-    loadingCommits: false,
-    backgroundLoading: false,
-    hasMore: !isLast,
-  })),
+  appendCommits: (commits, isLast) => set(s => {
+    if (s.reloading) {
+      // First batch of a reload replaces the list rather than appending, so the
+      // view never blanks out (no skeleton) while fresh data is in flight.
+      //
+      // Fast path: most refreshes are triggered by repo events that didn't change
+      // the graph at all (a fetch with nothing new, an index change, a file save).
+      // Keeping the *same array reference* when nothing changed means the
+      // commitsWithStashes memo, assignLanes, and the whole row tree all bail out
+      // of re-rendering — the refresh costs one comparison and zero DOM work.
+      const unchanged = commitListsEqual(s.commits, commits);
+      const sel = s.selectedCommit;
+      const selectionSurvives = unchanged || !sel || sel.isStash
+        || commits.some(c => c.hash === sel.hash && c.repoId === sel.repoId);
+      return {
+        commits: unchanged ? s.commits : commits,
+        reloading: false,
+        loadingCommits: false,
+        backgroundLoading: false,
+        hasMore: !isLast,
+        ...(selectionSurvives ? {} : { selectedCommit: null, selectedFile: null, commitFiles: [], currentDiff: null }),
+      };
+    }
+    return {
+      commits: [...s.commits, ...commits],
+      loadingCommits: false,
+      backgroundLoading: false,
+      hasMore: !isLast,
+    };
+  }),
   setCommits: (commits, hasMore) => set({ commits, hasMore, loadingCommits: false, backgroundLoading: false }),
-  resetCommits: () => set({ commits: [], stashes: [], hasMore: true, backgroundLoading: false, loadingCommits: true, selectedCommit: null, commitFiles: [], currentDiff: null }),
+  resetCommits: () => set({ commits: [], stashes: [], hasMore: true, reloading: false, backgroundLoading: false, loadingCommits: true, selectedCommit: null, commitFiles: [], currentDiff: null }),
+  // Warm refresh: keep the current commits (and selection) on screen until the
+  // replacement batch lands. Only the thin progress bar indicates the reload.
+  beginReload: () => set({ reloading: true, loadingCommits: true }),
   selectCommit: (commit) => set(s => ({ selectedCommit: commit, commitFiles: [], currentDiff: null, selectedFile: null, fileLoadSeq: s.fileLoadSeq + 1 })),
   setCommitFiles: (files) => set({ commitFiles: files, loadingFiles: false }),
   selectFile: (file) => set({ selectedFile: file }),
@@ -128,5 +193,10 @@ export const useLogStore = create<LogState>((set, get) => ({
   })),
   setError: (err) => set({ error: err }),
   setPendingScrollHash: (hash) => set({ pendingScrollHash: hash }),
-  setStashes: (stashes) => set({ stashes }),
+  setStashes: (stashes) => set(s => (
+    // Same reasoning as the commit bail-out: stashes are merged into the row list,
+    // so handing back a new array reference for an unchanged set of stashes would
+    // re-trigger assignLanes on every refresh and undo that fast path.
+    commitListsEqual(s.stashes, stashes) ? {} : { stashes }
+  )),
 }));

--- a/src/webview/gitLog/utils/graphLayout.ts
+++ b/src/webview/gitLog/utils/graphLayout.ts
@@ -190,11 +190,13 @@ export function assignLanes(commits: CommitNode[], isFiltered = false): GraphLay
   // the graph shows only dots with no connecting lines between unrelated results.
   if (commits.length === 0) return { commits: [], segments: [], totalCols: 1, refColors: new Map() };
 
-  // Always filter out parents not in the visible set — without this, commits whose
-  // parent hasn't been loaded yet (or was filtered out) create dangling branches that
-  // never close, corrupting the graph layout.
-  const visibleHashes = new Set(commits.map(c => c.hash));
-  commits = commits.map(c => ({ ...c, parents: c.parents.filter(p => visibleHashes.has(p)) }));
+  // Parents outside the loaded window are deliberately kept. They resolve to the null
+  // vertex below, which holds the branch's column open and runs its line off the bottom
+  // edge — the same thing git-graph does, and what makes the layout stable while paging.
+  // Dropping them instead ends the branch early, returning its column and colour to the
+  // pool for another branch to take; when the next page arrives and the parent shows up,
+  // the branch continues and every allocation after it shifts. On this repo that moved
+  // half the rows already on screen (73 of 150) to a different lane per page loaded.
 
   const n = commits.length;
   const hashIndex = new Map<string, number>();

--- a/src/webview/undockedPanel/main.tsx
+++ b/src/webview/undockedPanel/main.tsx
@@ -42,9 +42,10 @@ function generateId() {
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
 }
 
-const LOAD_STEP = 150;
-// Upper bound on how many commits a warm refresh re-requests in one go.
-const REFRESH_LIMIT_MAX = 3000;
+// Commits per page. The ceiling on the graph as a whole is the host's
+// gitcharm.graphMaxCommits, which clamps every request and reports the last batch,
+// so there is nothing to bound here.
+const PAGE_SIZE = 150;
 
 // ── Log sub-app ───────────────────────────────────────────────────────────────
 
@@ -125,12 +126,12 @@ function LogApp() {
 
     const initReqId = generateId();
     activeRequestIdRef.current = initReqId;
-    send({ type: 'LOG_REQUEST_COMMITS', repoIds: [], limit: LOAD_STEP, skip: 0, requestId: initReqId });
+    send({ type: 'LOG_REQUEST_COMMITS', repoIds: [], limit: PAGE_SIZE, skip: 0, requestId: initReqId });
 
     return () => window.removeEventListener('message', handler);
   }, []);
 
-  const sendAppendRequest = useCallback((f: import('../gitLog/store/logStore').CommitFilters, skip: number, limit: number = LOAD_STEP) => {
+  const sendAppendRequest = useCallback((f: import('../gitLog/store/logStore').CommitFilters, skip: number, limit: number = PAGE_SIZE) => {
     if (loadingInFlightRef.current) return;
     loadingInFlightRef.current = true;
     const reqId = generateId();
@@ -174,7 +175,10 @@ function LogApp() {
       reloadCommits();
       return;
     }
-    const limit = Math.min(REFRESH_LIMIT_MAX, Math.ceil(s.commits.length / LOAD_STEP) * LOAD_STEP);
+    // Round up to whole pages. Asking for more than the ceiling allows is fine — the
+    // host clamps it — but asking for less than is loaded would truncate the list and
+    // drop rows out from under the viewport.
+    const limit = Math.ceil(s.commits.length / PAGE_SIZE) * PAGE_SIZE;
     s.beginReload();
     sendAppendRequest(s.commitFilters, 0, limit);
   }, [sendAppendRequest, reloadCommits]);

--- a/src/webview/undockedPanel/main.tsx
+++ b/src/webview/undockedPanel/main.tsx
@@ -43,6 +43,8 @@ function generateId() {
 }
 
 const LOAD_STEP = 150;
+// Upper bound on how many commits a warm refresh re-requests in one go.
+const REFRESH_LIMIT_MAX = 3000;
 
 // ── Log sub-app ───────────────────────────────────────────────────────────────
 
@@ -128,7 +130,7 @@ function LogApp() {
     return () => window.removeEventListener('message', handler);
   }, []);
 
-  const sendAppendRequest = useCallback((f: import('../gitLog/store/logStore').CommitFilters, skip: number) => {
+  const sendAppendRequest = useCallback((f: import('../gitLog/store/logStore').CommitFilters, skip: number, limit: number = LOAD_STEP) => {
     if (loadingInFlightRef.current) return;
     loadingInFlightRef.current = true;
     const reqId = generateId();
@@ -137,7 +139,7 @@ function LogApp() {
     getVsCodeApi().postMessage({
       type: 'LOG_REQUEST_COMMITS',
       repoIds: f.repoId ? [f.repoId] : [],
-      limit: LOAD_STEP,
+      limit,
       skip,
       requestId: reqId,
       filterText: f.text || undefined,
@@ -161,7 +163,23 @@ function LogApp() {
     sendAppendRequest(f, 0);
   }, [sendAppendRequest]);
 
-  reloadRef.current = reloadCommits;
+  // Refresh triggered by a repo change (not by the user changing filters): keep the
+  // existing rows visible and swap them for the fresh ones when they arrive, so the
+  // skeleton only ever appears on a cold start. Re-request as many commits as are
+  // currently loaded, so a deep-scrolled list doesn't shrink and jump under the user.
+  const refreshCommits = useCallback(() => {
+    loadingInFlightRef.current = false;
+    const s = useLogStore.getState();
+    if (s.commits.length === 0) {
+      reloadCommits();
+      return;
+    }
+    const limit = Math.min(REFRESH_LIMIT_MAX, Math.ceil(s.commits.length / LOAD_STEP) * LOAD_STEP);
+    s.beginReload();
+    sendAppendRequest(s.commitFilters, 0, limit);
+  }, [sendAppendRequest, reloadCommits]);
+
+  reloadRef.current = refreshCommits;
 
   useEffect(() => {
     const { selectedCommit } = store;

--- a/src/webview/undockedPanel/main.tsx
+++ b/src/webview/undockedPanel/main.tsx
@@ -131,7 +131,7 @@ function LogApp() {
     return () => window.removeEventListener('message', handler);
   }, []);
 
-  const sendAppendRequest = useCallback((f: import('../gitLog/store/logStore').CommitFilters, skip: number, limit: number = PAGE_SIZE) => {
+  const sendAppendRequest = useCallback((f: import('../gitLog/store/logStore').CommitFilters, limit: number = PAGE_SIZE) => {
     if (loadingInFlightRef.current) return;
     loadingInFlightRef.current = true;
     const reqId = generateId();
@@ -141,7 +141,7 @@ function LogApp() {
       type: 'LOG_REQUEST_COMMITS',
       repoIds: f.repoId ? [f.repoId] : [],
       limit,
-      skip,
+      skip: 0,
       requestId: reqId,
       filterText: f.text || undefined,
       filterAuthor: f.author || undefined,
@@ -151,17 +151,23 @@ function LogApp() {
     } satisfies LogToHostMsg);
   }, []);
 
+  // Paging asks for a longer prefix of the same traversal rather than the next slice
+  // after a --skip. Two things follow: the rows already on screen keep their order and
+  // their lanes, because the list only ever grows at the tail; and a refresh, which asks
+  // for that same prefix, gets back exactly what is displayed instead of a differently
+  // ordered list assembled from independently sorted pages.
   const loadMore = useCallback(() => {
     const s = useLogStore.getState();
     if (loadingInFlightRef.current || !s.hasMore) return;
-    sendAppendRequest(s.commitFilters, s.commits.length);
+    s.beginReload();
+    sendAppendRequest(s.commitFilters, s.commits.length + PAGE_SIZE);
   }, [sendAppendRequest]);
 
   const reloadCommits = useCallback((overrides?: Partial<import('../gitLog/store/logStore').CommitFilters>) => {
     loadingInFlightRef.current = false;
     const f = { ...useLogStore.getState().commitFilters, ...overrides };
     useLogStore.getState().resetCommits();
-    sendAppendRequest(f, 0);
+    sendAppendRequest(f);
   }, [sendAppendRequest]);
 
   // Refresh triggered by a repo change (not by the user changing filters): keep the
@@ -180,7 +186,7 @@ function LogApp() {
     // drop rows out from under the viewport.
     const limit = Math.ceil(s.commits.length / PAGE_SIZE) * PAGE_SIZE;
     s.beginReload();
-    sendAppendRequest(s.commitFilters, 0, limit);
+    sendAppendRequest(s.commitFilters, limit);
   }, [sendAppendRequest, reloadCommits]);
 
   reloadRef.current = refreshCommits;


### PR DESCRIPTION
The Git Log lost your scroll position on every refresh — and a branch switch, file save or autofetch is a refresh. Four causes:

- **Skeleton shimmer on refresh** wiped rows, selection and scroll. → Replace rows in place; skeleton only on cold start and filter changes. Unchanged refresh returns the same array reference, so nothing re-renders. Scroll anchored to the top visible commit.
- **`graphMaxCommits` capped each request, not the list.** Paging grew past it, then a refresh asked for everything loaded, got capped, and came back truncated — anchor commit gone, scroll clamped to the bottom. → Cap `skip + limit`.
- **`assignLanes` dropped parents not yet loaded.** Branch ended early, freed its column, then continued when the next page arrived — moving every lane below it. → Keep the parent; it resolves to the null vertex and holds the column open, as git-graph does.
- **Each `--skip` page was date-sorted alone**, so paged order never matched a single-request refresh. → Page by growing prefix, and use `--date-order` so git's order matches the display.

Measured on a 1400-commit repo:

| | before | after |
| --- | --- | --- |
| lanes changed loading page 2 | 73 of 150 | 1 |
| rows moved on refresh at 600 | 207 of 600 | 0 |
| graph columns at 600 rows | 18 | 11 |

**Breaking:** `graphMaxCommits` is now enforced — scrolling stops there instead of walking past it. Raise it if you set it low.