### PR TITLE
Copy branch names from the context menu

### DIFF
--- a/src/webview/gitLog/components/BranchSidebar.tsx
+++ b/src/webview/gitLog/components/BranchSidebar.tsx
@@ -527,6 +527,10 @@ function ContextMenu({ merged, x, y, canDelete, onClose, onCheckout, onMerge, on
       document.removeEventListener('keydown', onKeyDown);
     };
   }, [onClose]);
+  const copyName = () => {
+    navigator.clipboard.writeText(merged.baseName).catch(() => {});
+    onClose();
+  };
   const items: MenuItem[] = [
     { icon: 'arrow-right', label: `Checkout "${merged.baseName}"`, action: onCheckout },
     { sep: true },
@@ -537,6 +541,8 @@ function ContextMenu({ merged, x, y, canDelete, onClose, onCheckout, onMerge, on
       ...(onPull ? [{ icon: 'cloud-download', label: `Pull "${merged.baseName}"`, action: onPull }] : []),
       ...(onPush ? [{ icon: 'cloud-upload', label: `Push "${merged.baseName}"...`, action: onPush }] : []),
     ] : []),
+    { sep: true },
+    { icon: 'copy', label: 'Copy Branch Name', action: copyName },
     ...(canDelete ? [{ sep: true as const }, { icon: 'trash', label: 'Delete branch', action: onDelete, danger: true }] : []),
   ];
 


### PR DESCRIPTION


## Description

Adds a **Copy Branch Name** action to the branch context menu in the Git Log sidebar.

The action copies the displayed local or remote branch name to the clipboard and is available in both docked and undocked Git Log views.

<img height="250" alt="image" src="https://github.com/user-attachments/assets/2263f34d-edb7-4a28-b335-3fe52e7eec88" />

## Validation

- Host TypeScript check passed
- Webview TypeScript check passed
- Production build passed
- Changed-file ESLint completed without errors
- `git diff --check` passed