### PR TITLE
Match VS Code's commit message behavior in the Commit panel

### DIFF
--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -122,7 +122,7 @@ export class GitService {
       }
     }
 
-    return { repoId: this.repoId, branch: freshBranchInfo, stagedFiles, unstagedFiles, isDetachedHead: status.detached, conflictCount };
+    return { repoId: this.repoId, branch: freshBranchInfo, stagedFiles, unstagedFiles, isDetachedHead: status.detached, conflictCount, mergeRebaseState: await this.getMergeRebaseState() ?? undefined };
   }
 
   private async getShortHash(): Promise<string | undefined> {
@@ -293,6 +293,7 @@ export class GitService {
         unstagedFiles,
         isDetachedHead: isDetached,
         conflictCount,
+        mergeRebaseState: await this.getMergeRebaseState() ?? undefined,
       };
     }
 
@@ -326,7 +327,7 @@ export class GitService {
       }
     }
 
-    return { repoId: this.repoId, branch: branchInfo, stagedFiles, unstagedFiles, isDetachedHead: status.detached, conflictCount };
+    return { repoId: this.repoId, branch: branchInfo, stagedFiles, unstagedFiles, isDetachedHead: status.detached, conflictCount, mergeRebaseState: await this.getMergeRebaseState() ?? undefined };
   }
 
   async getCurrentBranch(): Promise<BranchInfo> {
@@ -1156,20 +1157,27 @@ export class GitService {
     return this.commitTemplate();
   }
 
+  /**
+   * Whether a merge or rebase is still open. Read off the git dir rather than the
+   * VS Code API, which only reports a merge while conflicts are unresolved — the
+   * operation is still in progress after they are staged, and that is exactly when
+   * the panel needs to offer Continue. Cheap enough for every status refresh.
+   */
   async getMergeRebaseState(): Promise<'merge' | 'rebase' | null> {
-    const vsRepo = this.vsRepo();
-    if (vsRepo) {
-      if (vsRepo.state.rebaseCommit !== undefined) return 'rebase';
-      if (vsRepo.state.mergeChanges.length > 0) return 'merge';
-      return null;
-    }
-    const mergeHead = await this.git.raw(['rev-parse', '--verify', 'MERGE_HEAD']).catch(() => '');
-    if (mergeHead.trim()) return 'merge';
-    const rebaseDir = await this.git.raw(['rev-parse', '--git-path', 'rebase-merge']).catch(() => '');
-    try {
-      if (rebaseDir.trim() && fs.existsSync(rebaseDir.trim())) return 'rebase';
-    } catch { /* */ }
+    const dir = await this.gitDir();
+    const exists = (name: string) => { try { return fs.existsSync(path.join(dir, name)); } catch { return false; } };
+    // Rebase wins: an interactive rebase can leave MERGE_HEAD behind on a conflicted pick.
+    if (exists('rebase-merge') || exists('rebase-apply')) return 'rebase';
+    if (exists('MERGE_HEAD')) return 'merge';
     return null;
+  }
+
+  async rebaseContinue(): Promise<void> {
+    // `rebase --continue` opens an editor for the commit being replayed. core.editor=true
+    // is the no-op shell builtin, so the stored message is accepted unchanged and the
+    // command never blocks — simple-git needs allowUnsafeEditor to let the override past.
+    await simpleGit(this.rootPath, { unsafe: { allowUnsafeEditor: true } })
+      .raw(['-c', 'core.editor=true', 'rebase', '--continue']);
   }
 
   async abortMerge(): Promise<void> {

--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -47,6 +47,11 @@ function vsStatusToGitFileStatus(s: Status): GitFileStatus {
   }
 }
 
+/** Drops the comment lines git adds to prepared commit messages, the way `git commit` would. */
+function stripCommitComments(raw: string): string {
+  return raw.replace(/^\s*#.*$\n?/gm, '').trim();
+}
+
 export class GitService {
   private git: SimpleGit;
   // Set immediately after a tag checkout, cleared when VS Code API confirms the update.
@@ -1097,6 +1102,58 @@ export class GitService {
     }
     const result = await this.git.commit(message, undefined, amend ? { '--amend': null } : {});
     return result.summary.changes.toString();
+  }
+
+  /**
+   * Absolute path of the repo's git dir. It is a plain file for worktrees and
+   * submodules, so resolve it through git once and cache it.
+   */
+  private gitDirPromise?: Promise<string>;
+  private gitDir(): Promise<string> {
+    return this.gitDirPromise ??= this.git
+      .raw(['rev-parse', '--absolute-git-dir'])
+      .then(out => out.trim() || path.join(this.rootPath, '.git'))
+      .catch(() => path.join(this.rootPath, '.git'));
+  }
+
+  // ponytail: commit.template is resolved once per session; a mid-session config
+  // change needs a window reload. Watch .git/config if that ever matters.
+  private commitTemplatePromise?: Promise<string>;
+  private commitTemplate(): Promise<string> {
+    return this.commitTemplatePromise ??= (async () => {
+      const configured = (await this.git.raw(['config', '--get', 'commit.template']).catch(() => '')).trim();
+      if (!configured) return '';
+      // git expands a leading ~ / ~user itself — mirror that before reading.
+      let templatePath = configured.replace(/^~([^/]*)\//, (_m, user: string) =>
+        `${user ? path.join(path.dirname(os.homedir()), user) : os.homedir()}/`);
+      if (!path.isAbsolute(templatePath)) templatePath = path.join(this.rootPath, templatePath);
+      try {
+        return stripCommitComments(fs.readFileSync(templatePath, 'utf8'));
+      } catch {
+        return '';
+      }
+    })();
+  }
+
+  /**
+   * The message the commit box should seed itself with when empty — the same sources
+   * VS Code's Source Control input uses: the message git prepared for an in-progress
+   * merge or squash, otherwise the configured commit.template. Empty when there is
+   * nothing to seed.
+   */
+  async getInputTemplate(): Promise<string> {
+    const dir = await this.gitDir();
+    for (const name of ['MERGE_MSG', 'SQUASH_MSG']) {
+      let raw: string;
+      try {
+        raw = fs.readFileSync(path.join(dir, name), 'utf8');
+      } catch {
+        continue; // no merge / squash in progress
+      }
+      const message = stripCommitComments(raw);
+      if (message) return message;
+    }
+    return this.commitTemplate();
   }
 
   async getMergeRebaseState(): Promise<'merge' | 'rebase' | null> {

--- a/src/host/panels/CommitPanelProvider.ts
+++ b/src/host/panels/CommitPanelProvider.ts
@@ -731,6 +731,25 @@ export class CommitPanelProvider implements vscode.WebviewViewProvider {
         break;
       }
 
+      case 'COMMIT_REBASE_ACTION': {
+        const repo = this.manager.getRepo(msg.repoId);
+        if (!repo) { logWarn('rebase-action', 'Repo not found'); this.post({ type: 'COMMIT_OP_RESULT', requestId: msg.requestId, ok: false, error: 'Repo not found' }); return; }
+        try {
+          if (msg.action === 'continue') await repo.rebaseContinue();
+          else await repo.abortRebase();
+          this.post({ type: 'COMMIT_OP_RESULT', requestId: msg.requestId, ok: true });
+          logInfo('rebase-action', `Rebase ${msg.action} in ${msg.repoId}`);
+          this.logProvider?.refresh();
+        } catch (e: unknown) {
+          logError('rebase-action', formatGitError(e), getRawErrorDetail(e));
+          this.post({ type: 'COMMIT_OP_RESULT', requestId: msg.requestId, ok: false, error: formatGitError(e) });
+        }
+        const rebaseStatus = await this.manager.getAllStatusesFresh();
+        this.post({ type: 'COMMIT_STATUS_UPDATE', repos: this.manager.getRepoMetas(), status: rebaseStatus });
+        this.postChangelistsUpdate(rebaseStatus);
+        break;
+      }
+
       case 'OPEN_PROFILES_MENU': {
         vscode.commands.executeCommand('gitcharm.manageProfiles');
         break;

--- a/src/host/panels/CommitPanelProvider.ts
+++ b/src/host/panels/CommitPanelProvider.ts
@@ -100,8 +100,19 @@ export class CommitPanelProvider implements vscode.WebviewViewProvider {
     this.handleMessage(msg, undefined as unknown as vscode.Webview).finally(() => { this.activeReplyTarget = 'sidebar'; });
   }
 
-  prefillCommitMessage(message: string): void {
-    this.post({ type: 'COMMIT_SET_MESSAGE', message });
+  /**
+   * Seeds the commit box with the message git prepared for an in-progress merge or
+   * squash (or the configured commit.template), matching VS Code's Source Control
+   * input. Only fills an empty box, so a message the user typed is never clobbered.
+   */
+  async seedCommitMessage(): Promise<void> {
+    for (const meta of this.manager.getRepoMetas()) {
+      const message = await this.manager.getRepo(meta.id)?.getInputTemplate().catch(() => '');
+      if (message) {
+        this.broadcastCommit({ type: 'COMMIT_SET_MESSAGE', message, ifEmpty: true });
+        return;
+      }
+    }
   }
   private shelveServices = new Map<string, ShelveService>();
 
@@ -322,6 +333,9 @@ export class CommitPanelProvider implements vscode.WebviewViewProvider {
   private syncBadgeFromMsg(msg: HostToCommitMsg): void {
     if (msg.type === 'COMMIT_STATUS_UPDATE') {
       this.badgeController?.update(msg.status);
+      // A merge can start anywhere (terminal, VS Code's own panel, a pull), so re-seed
+      // off every status refresh rather than only from GitCharm's own merge command.
+      void this.seedCommitMessage();
     }
   }
 

--- a/src/host/panels/GitLogPanelProvider.ts
+++ b/src/host/panels/GitLogPanelProvider.ts
@@ -904,10 +904,7 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
           logError('merge', errMsg, getRawErrorDetail(e));
           this.post({ type: 'LOG_BRANCH_OP_RESULT', requestId: msg.requestId, ok: false, error: errMsg });
           if (errMsg.includes('CONFLICT')) {
-            repo.getCurrentBranch().then(current => {
-              const mergeMsg = `Merge branch '${msg.from}' into '${current.name}'`;
-              this.commitPanel?.prefillCommitMessage(mergeMsg);
-            }).catch(() => {});
+            void this.commitPanel?.seedCommitMessage();
             vscode.window.showWarningMessage(
               'Merge conflicts detected. Use the Merge Editor to resolve them.',
               'Open Commit Panel'

--- a/src/host/types/git.ts
+++ b/src/host/types/git.ts
@@ -164,4 +164,6 @@ export interface RepoStatus {
   unstagedFiles: FileStatus[];
   isDetachedHead: boolean;
   conflictCount: number;
+  /** Set while a merge or rebase is still open, so the panel can offer Continue / Abort. */
+  mergeRebaseState?: 'merge' | 'rebase';
 }

--- a/src/host/types/messages.ts
+++ b/src/host/types/messages.ts
@@ -103,6 +103,7 @@ export type CommitToHostMsg =
   | { type: 'COMMIT_DO_COMMIT'; requestId: string; repoId: string; message: string; amend: boolean }
   | { type: 'COMMIT_DO_COMMIT_PUSH'; requestId: string; repoId: string; message: string; amend: boolean }
   | { type: 'COMMIT_DO_COMMIT_MULTI'; requestId: string; repos: Array<{ repoId: string; message: string; amend: boolean; filesToStage: string[]; filesToUnstage: string[] }>; andPush: boolean }
+  | { type: 'COMMIT_REBASE_ACTION'; requestId: string; repoId: string; action: 'continue' | 'abort' }
   | { type: 'COMMIT_PULL_ALL' }
   | { type: 'COMMIT_PULL_REPO'; requestId: string; repoId: string }
   | { type: 'COMMIT_GET_REMOTES'; requestId: string; repoId: string }

--- a/src/host/types/messages.ts
+++ b/src/host/types/messages.ts
@@ -79,7 +79,7 @@ export type HostToCommitMsg =
   | { type: 'PUSH_DROP_RESULT'; requestId: string; ok: boolean; error?: string }
   | { type: 'PUSH_REVERT_RESULT'; requestId: string; ok: boolean; error?: string }
   | { type: 'PUSH_EDIT_MSG_RESULT'; requestId: string; ok: boolean; error?: string }
-  | { type: 'COMMIT_SET_MESSAGE'; message: string }
+  | { type: 'COMMIT_SET_MESSAGE'; message: string; ifEmpty?: boolean }
   | { type: 'CHANGELISTS_UPDATE'; changelists: ChangelistData[]; viewMode: 'simplified' | 'changelists' | 'vscode' }
   | { type: 'SUBMODULE_OP_RESULT'; requestId: string; parentRepoId: string; submodulePath: string; op: 'init' | 'deinit' | 'update'; ok: boolean; error?: string }
   | { type: 'SUBMODULE_PUSH_RESULT'; requestId: string; repoId: string; ok: boolean; error?: string }

--- a/src/webview/commitPanel/components/UnifiedCommitForm.tsx
+++ b/src/webview/commitPanel/components/UnifiedCommitForm.tsx
@@ -39,6 +39,7 @@ interface Props {
   generatingMessage: boolean;
   activeProfile?: { name: string; gitName: string; gitEmail: string; builtIn?: 'local' | 'global' };
   onOpenProfiles: () => void;
+  onRebaseAction: (repoId: string, action: 'continue' | 'abort') => void;
 }
 
 interface DropdownButtonItem { icon: string; label: string; onSelect: () => void; }
@@ -202,7 +203,7 @@ export function UnifiedCommitForm({
   loading, changesViewMode, defaultCommitAction = 'commit', defaultSaveAction = 'stash', vscodeSelectedRepos, getSelectedFilesForRepo, onDeselectRepo, onMessageChange, onAmendToggle, onCommit, onCommitAndPush, onShelve, onStash,
   onSyncAction, onPullRepos, onPushRepos, onForcePushRepos,
   aiEnabled, onAutopilot, onAutopilotContextMenu, generatingMessage,
-  activeProfile, onOpenProfiles,
+  activeProfile, onOpenProfiles, onRebaseAction,
 }: Props) {
   const metaMap = new Map(repoMetas.map(m => [m.id, m]));
   const [textareaFocused, setTextareaFocused] = useState(false);
@@ -223,6 +224,14 @@ export function UnifiedCommitForm({
   const syncRepos = syncRepoStatuses ?? repoStatuses;
   const sync = computeSyncState(syncRepos);
   const showSync = !hasWorkingChanges(syncRepos) && sync.action !== 'none' && !loading;
+
+  // A plain commit does not finish a rebase — git still needs `rebase --continue`, so
+  // the primary action becomes Continue until the rebase is done. A merge needs no
+  // special case: `git commit` completes it, which is what VS Code does too.
+  // Only the repo the user is about to commit takes over the button; a rebase open in
+  // some other repo of the workspace must not block committing this one.
+  const rebasing = commitTargets.find(r => r.mergeRebaseState === 'rebase')
+    ?? (commitTargets.length === 0 ? syncRepos.find(r => r.mergeRebaseState === 'rebase') : undefined);
 
   const amendTarget = commitTargets.length === 1 ? commitTargets[0] : null;
   const showAmend = amendTarget !== null && (amendTarget.branch.aheadBehind?.ahead ?? 0) > 0;
@@ -458,7 +467,22 @@ export function UnifiedCommitForm({
         </div>
 
         <div style={styles.rightActions}>
-          {showSync ? (
+          {rebasing ? (
+            <DropdownButton
+              variant="primary"
+              fullWidth
+              dropdownAlign="right"
+              enabled={!loading}
+              icon="debug-continue"
+              label="Continue Rebase"
+              title={`Continue the rebase in ${metaMap.get(rebasing.repoId)?.name ?? rebasing.repoId}`}
+              items={[
+                { icon: 'debug-continue', label: 'Continue Rebase', onSelect: () => onRebaseAction(rebasing.repoId, 'continue') },
+                { icon: 'error',          label: 'Abort Rebase',    onSelect: () => onRebaseAction(rebasing.repoId, 'abort')    },
+              ]}
+              onMainClick={() => onRebaseAction(rebasing.repoId, 'continue')}
+            />
+          ) : showSync ? (
             <DropdownButton
               variant="primary"
               fullWidth

--- a/src/webview/commitPanel/main.tsx
+++ b/src/webview/commitPanel/main.tsx
@@ -460,6 +460,7 @@ function App() {
           }
           break;
         case 'COMMIT_SET_MESSAGE':
+          if (msg.ifEmpty && useCommitStore.getState().commitMessage.trim()) break;
           store.setCommitMessage(msg.message);
           break;
         case 'SHELVE_LIST_RESULT':

--- a/src/webview/commitPanel/main.tsx
+++ b/src/webview/commitPanel/main.tsx
@@ -290,6 +290,8 @@ function App() {
 
   // Track unstaged file counts per repo to detect new changes for auto-expand in vscode mode
   const prevUnstagedCountsRef = useRef<Map<string, number>>(new Map());
+  // The in-flight commit, so its message is only cleared once the commit succeeded.
+  const pendingCommitRef = useRef<{ requestId: string; repoIds: string[] } | null>(null);
 
   // ── Vscode mode: repo selection for commit ───────────────────────────────
   const [vscodeSelectedRepos, setVscodeSelectedRepos] = useState<Set<string>>(new Set());
@@ -441,6 +443,16 @@ function App() {
           break;
         case 'COMMIT_OP_RESULT':
           store.setLoading(false);
+          if (pendingCommitRef.current?.requestId === msg.requestId) {
+            const { repoIds } = pendingCommitRef.current;
+            pendingCommitRef.current = null;
+            // Only a successful commit consumes the message — a rejecting hook or a
+            // missing identity must not cost the user what they typed.
+            if (msg.ok) {
+              store.setCommitMessage('');
+              repoIds.forEach(id => store.clearAmend(id));
+            }
+          }
           if (msg.ok) {
             // Refresh push tab after any successful operation (commit, undo, push, etc.)
             const currentRepos = useCommitStore.getState().status?.repos ?? [];
@@ -1094,9 +1106,9 @@ function App() {
       if (targets.length === 0) return;
       store.setLoading(true);
 
-      getVsCodeApi().postMessage({ type: 'COMMIT_DO_COMMIT_MULTI', requestId: generateId(), repos: targets, andPush } satisfies CommitToHostMsg);
-      store.setCommitMessage('');
-      targets.forEach(t => store.clearAmend(t.repoId));
+      const requestId = generateId();
+      pendingCommitRef.current = { requestId, repoIds: targets.map(t => t.repoId) };
+      getVsCodeApi().postMessage({ type: 'COMMIT_DO_COMMIT_MULTI', requestId, repos: targets, andPush } satisfies CommitToHostMsg);
       return;
     }
 
@@ -1129,9 +1141,9 @@ function App() {
     if (targets.length === 0) return;
     store.setLoading(true);
     store.setError(null);
-    getVsCodeApi().postMessage({ type: 'COMMIT_DO_COMMIT_MULTI', requestId: generateId(), repos: targets, andPush } satisfies CommitToHostMsg);
-    store.setCommitMessage('');
-    targets.forEach(t => store.clearAmend(t.repoId));
+    const requestId = generateId();
+    pendingCommitRef.current = { requestId, repoIds: targets.map(t => t.repoId) };
+    getVsCodeApi().postMessage({ type: 'COMMIT_DO_COMMIT_MULTI', requestId, repos: targets, andPush } satisfies CommitToHostMsg);
   };
 
   // ── Render ────────────────────────────────────────────────────────────────
@@ -1485,6 +1497,10 @@ function App() {
             generatingMessage={generatingMessage}
             activeProfile={store.activeProfile}
             onOpenProfiles={() => send({ type: 'OPEN_PROFILES_MENU' } satisfies CommitToHostMsg)}
+            onRebaseAction={(repoId, action) => {
+              store.setLoading(true);
+              send({ type: 'COMMIT_REBASE_ACTION', requestId: generateId(), repoId, action } satisfies CommitToHostMsg);
+            }}
             onShelve={() => {
               const name = store.commitMessage.trim();
               if (!name) return;

--- a/src/webview/commitPanel/store/commitStore.ts
+++ b/src/webview/commitPanel/store/commitStore.ts
@@ -85,6 +85,19 @@ function savePersistedSelection(mode: 'simplified' | 'changelists', repoId: stri
   } catch { /* ignore */ }
 }
 
+const COMMIT_MESSAGE_KEY = 'gitcharm:commitMessage';
+
+function loadPersistedCommitMessage(): string {
+  try { return localStorage.getItem(COMMIT_MESSAGE_KEY) ?? ''; } catch { return ''; }
+}
+
+function savePersistedCommitMessage(msg: string) {
+  try {
+    if (msg) localStorage.setItem(COMMIT_MESSAGE_KEY, msg);
+    else localStorage.removeItem(COMMIT_MESSAGE_KEY);
+  } catch { /* ignore */ }
+}
+
 export const useCommitStore = create<CommitState>((set, get) => ({
   status: null,
   repoMetas: [],
@@ -96,7 +109,8 @@ export const useCommitStore = create<CommitState>((set, get) => ({
   selectedFile: null,
   currentDiff: null,
   loadingDiff: false,
-  commitMessage: '',
+  // Survives a window reload, the way VS Code's Source Control input does.
+  commitMessage: loadPersistedCommitMessage(),
   amendFlags: {},
   viewAndSort: DEFAULT_VIEW_AND_SORT_SETTINGS,
   shelveCollapsedKeys: new Set(),
@@ -206,7 +220,7 @@ export const useCommitStore = create<CommitState>((set, get) => ({
 
   setDiff: (diff) => set({ currentDiff: diff, loadingDiff: false }),
   setLoadingDiff: (v) => set({ loadingDiff: v }),
-  setCommitMessage: (msg) => set({ commitMessage: msg }),
+  setCommitMessage: (msg) => { savePersistedCommitMessage(msg); set({ commitMessage: msg }); },
   setAmend: (repoId, v) => set(s => ({ amendFlags: { ...s.amendFlags, [repoId]: v } })),
   clearAmend: (repoId) => set(s => {
     if (!(repoId in s.amendFlags)) return s;

--- a/src/webview/shared/types.ts
+++ b/src/webview/shared/types.ts
@@ -138,6 +138,8 @@ export interface RepoStatus {
   unstagedFiles: FileStatus[];
   isDetachedHead: boolean;
   conflictCount: number;
+  /** Set while a merge or rebase is still open, so the panel can offer Continue / Abort. */
+  mergeRebaseState?: 'merge' | 'rebase';
 }
 
 // ─── Changelists ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Four ways the Commit panel diverged from VS Code's built-in Source Control view.

- **Empty message during a merge conflict.** The box never read `.git/MERGE_MSG`,
  `SQUASH_MSG` or `commit.template`. New `GitService.getInputTemplate()` reads all
  three (git dir resolved via `rev-parse`, so worktrees and submodules work; comment
  lines stripped), and the panel seeds off every status refresh — so it fires whether
  the merge started in the terminal, VS Code's own panel, or a pull. Only ever fills an
  empty box.
- **A failed commit ate the message.** The box was cleared the moment the commit was
  posted, so a rejecting pre-commit hook or a missing Git identity cost the user what
  they typed. Message and amend flags now clear from the result handler, only on
  success.
- **Message didn't survive a window reload.** Persisted to `localStorage`, reusing the
  pattern the store already used for file selections.
- **A rebase couldn't be finished from the panel.** `git commit` doesn't end a rebase,
  so the primary button was a dead end. `RepoStatus` now carries `mergeRebaseState` and
  the button becomes *Continue Rebase* (Abort in its dropdown) for the repo being
  committed — a rebase open in another repo of the workspace leaves it alone.

Also:

- `getMergeRebaseState()` reads the git dir instead of the VS Code API, which reported
  `null` once conflicts were staged — exactly when Continue is needed. Fixes the branch
  status bar's Abort in that window too.
- Drops the synthesized `Merge branch 'x' into 'y'` string the Git Log panel prefilled;
  it only covered merges started from GitCharm and ignored what git had already written.

Verified against real repos: merge/squash/template seeding, worktree case, state staying
`merge` after staging, `rebase --continue` replaying history without an editor prompt,
and message persistence across a reload and through throwing storage. Pre-existing
`tsc`/lint baselines unchanged.