### PR TITLE
Merge the ref shown in the branch menu, not a same-named local branch

### DIFF
--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -1371,7 +1371,13 @@ export class GitService {
     await this.git.branch(from ? [branchName, from] : [branchName]);
   }
 
-  async merge(from: string): Promise<void> {
+  /**
+   * Merge `from` into the current branch. Returns whether HEAD actually moved:
+   * git exits 0 with "Already up to date" when there is nothing to merge, and
+   * callers must not report that as a completed merge.
+   */
+  async merge(from: string): Promise<{ upToDate: boolean }> {
+    const before = await this.getFullHash();
     try {
       await this.git.merge([from]);
     } catch (e: unknown) {
@@ -1394,6 +1400,7 @@ export class GitService {
       }
       await this.git.stash(['pop']);
     }
+    return { upToDate: !!before && before === await this.getFullHash() };
   }
 
   async rebase(onto: string): Promise<void> {

--- a/src/host/panels/GitLogPanelProvider.ts
+++ b/src/host/panels/GitLogPanelProvider.ts
@@ -868,8 +868,10 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
         const repo = this.manager.getRepo(msg.repoId);
         if (!repo) { this.post({ type: 'LOG_BRANCH_OP_RESULT', requestId: msg.requestId, ok: false, error: 'Repo not found' }); return; }
         try {
-          await repo.merge(msg.from);
+          const { upToDate } = await repo.merge(msg.from);
           this.post({ type: 'LOG_BRANCH_OP_RESULT', requestId: msg.requestId, ok: true });
+          this.post({ type: 'LOG_REFRESH' });
+          if (upToDate) vscode.window.showInformationMessage(`"${msg.from}" is already up to date — nothing to merge.`);
         } catch (e: unknown) {
           const errMsg = formatGitError(e);
           const isDirty = errMsg.includes('Your local changes') || errMsg.includes('overwritten by merge') || (e as { gitErrorCode?: string })?.gitErrorCode === 'DirtyWorkTree';
@@ -892,8 +894,10 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
             if (pick?.value === 'stash') {
               try {
                 await repo.stashPush(`WIP before merge of ${msg.from}`);
-                await repo.merge(msg.from);
+                const { upToDate } = await repo.merge(msg.from);
                 this.post({ type: 'LOG_BRANCH_OP_RESULT', requestId: msg.requestId, ok: true });
+                this.post({ type: 'LOG_REFRESH' });
+                if (upToDate) vscode.window.showInformationMessage(`"${msg.from}" is already up to date — nothing to merge.`);
               } catch (e2: unknown) {
                 logError('merge:stash', formatGitError(e2), getRawErrorDetail(e2));
                 this.post({ type: 'LOG_BRANCH_OP_RESULT', requestId: msg.requestId, ok: false, error: String(e2) });
@@ -914,6 +918,10 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
             ).then(choice => {
               if (choice) vscode.commands.executeCommand('gitcharm.commitPanel.focus');
             });
+          } else {
+            // The webview only logs this to its console, so the failure is
+            // invisible unless it is reported here.
+            vscode.window.showErrorMessage(`Merge of "${msg.from}" failed: ${errMsg}`);
           }
         }
         break;
@@ -925,9 +933,11 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
         try {
           await repo.rebase(msg.onto);
           this.post({ type: 'LOG_BRANCH_OP_RESULT', requestId: msg.requestId, ok: true });
+          this.post({ type: 'LOG_REFRESH' });
         } catch (e: unknown) {
           logError('rebase', formatGitError(e), getRawErrorDetail(e));
           this.post({ type: 'LOG_BRANCH_OP_RESULT', requestId: msg.requestId, ok: false, error: formatGitError(e) });
+          vscode.window.showErrorMessage(`Rebase onto "${msg.onto}" failed: ${formatGitError(e)}`);
         }
         break;
       }

--- a/src/host/ui/BranchStatusBar.ts
+++ b/src/host/ui/BranchStatusBar.ts
@@ -428,7 +428,10 @@ export class BranchStatusBar implements vscode.Disposable {
         items.push({
           label: `$(cloud) ${fullName}`,
           description: '',
-          action: () => this.showCommonBranchActionMenu(baseName, metas, false, headLabel),
+          // Checkout/pull/rename work on the local branch, but merge, rebase and
+          // compare must use the remote ref the user actually picked — merging the
+          // same-named local branch instead is usually a silent no-op.
+          action: () => this.showCommonBranchActionMenu(baseName, metas, false, headLabel, fullName),
         });
       }
     }
@@ -688,6 +691,8 @@ export class BranchStatusBar implements vscode.Disposable {
     metas: RepoMeta[],
     isCurrent: boolean,
     currentBranchName: string,
+    /** Ref to merge/rebase/compare against — the remote ref for remote entries. */
+    ref: string = branchName,
   ): Promise<void> {
     type ActionItem = vscode.QuickPickItem & { action: () => Promise<void> | void };
 
@@ -721,16 +726,16 @@ export class BranchStatusBar implements vscode.Disposable {
       items.push(
         { label: '', kind: vscode.QuickPickItemKind.Separator, action: async () => {} },
         {
-          label: `$(git-compare) Compare with '${branchName}'…`,
-          action: () => this.compareBranchAllRepos(branchName, metas, currentBranchName),
+          label: `$(git-compare) Compare with '${ref}'…`,
+          action: () => this.compareBranchAllRepos(ref, metas, currentBranchName),
         },
         {
-          label: `$(repo-forked) Rebase '${currentBranchName}' onto '${branchName}'`,
-          action: () => this.rebaseAllRepos(branchName, metas),
+          label: `$(repo-forked) Rebase '${currentBranchName}' onto '${ref}'`,
+          action: () => this.rebaseAllRepos(ref, metas),
         },
         {
-          label: `$(git-merge) Merge '${branchName}' into '${currentBranchName}'`,
-          action: () => this.mergeBranchAllRepos(branchName, metas),
+          label: `$(git-merge) Merge '${ref}' into '${currentBranchName}'`,
+          action: () => this.mergeBranchAllRepos(ref, metas),
         },
       );
     }
@@ -1879,8 +1884,10 @@ export class BranchStatusBar implements vscode.Disposable {
     const repo = this.manager.getRepo(meta.id);
     if (!repo) return;
     try {
-      await repo.merge(from);
-      const msg = `[${meta.name}]: merged "${from}".`;
+      const { upToDate } = await repo.merge(from);
+      const msg = upToDate
+        ? `[${meta.name}]: "${from}" is already up to date — nothing to merge.`
+        : `[${meta.name}]: merged "${from}".`;
       vscode.window.showInformationMessage(msg);
       logInfo(`merge:${meta.name}`, msg);
     } catch (e: unknown) {
@@ -2082,11 +2089,12 @@ export class BranchStatusBar implements vscode.Disposable {
       { location: vscode.ProgressLocation.Notification, title: `Merging "${from}"…`, cancellable: false },
       async () => {
         const errors: string[] = [];
+        let merged = 0;
         for (const meta of metas) {
           const repo = this.manager.getRepo(meta.id);
           if (!repo) continue;
           try {
-            await repo.merge(from);
+            if (!(await repo.merge(from)).upToDate) merged++;
           } catch (e: unknown) {
             const errMsg = formatGitError(e);
             const isDirty = errMsg.includes('Your local changes') || errMsg.includes('overwritten by merge') || (e as { gitErrorCode?: string })?.gitErrorCode === 'DirtyWorkTree';
@@ -2105,7 +2113,7 @@ export class BranchStatusBar implements vscode.Disposable {
               if (pick?.value === 'stash') {
                 try {
                   await repo.stashPush(`WIP before merge of ${from}`);
-                  await repo.merge(from);
+                  if (!(await repo.merge(from)).upToDate) merged++;
                 } catch (e2: unknown) {
                   logError(`merge:${meta.name}`, formatGitError(e2), getRawErrorDetail(e2));
                   errors.push(`${meta.name}: ${String(e2)}`);
@@ -2121,7 +2129,9 @@ export class BranchStatusBar implements vscode.Disposable {
           void vscode.window.showWarningMessage(`${errors.length} error(s): ${errors.join('; ')}`, 'Show Log')
             .then(choice => { if (choice === 'Show Log') showLogChannel(); });
         } else {
-          const msg = `Merged "${from}" in ${metas.length} repos.`;
+          const msg = merged === 0
+            ? `"${from}" is already up to date — nothing to merge.`
+            : `Merged "${from}" in ${merged} ${merged === 1 ? 'repo' : 'repos'}.`;
           vscode.window.showInformationMessage(msg);
           logInfo('merge', msg);
         }

--- a/src/webview/gitLog/components/BranchSidebar.tsx
+++ b/src/webview/gitLog/components/BranchSidebar.tsx
@@ -284,6 +284,9 @@ export const BranchSidebar = forwardRef<HTMLDivElement, Props>(function BranchSi
       {/* Branch context menu */}
       {contextMenu && (() => {
         const inst = primaryInstance(contextMenu.merged);
+        // Merging or rebasing in the repo where this branch is already checked out
+        // does nothing — target a repo where it is not the current branch.
+        const opInst = contextMenu.merged.instances.find(i => !i.isHead) ?? inst;
         const localInstances = contextMenu.merged.instances.filter(instance => !instance.isRemote);
         const currentLocalRepoIds = localInstances.filter(instance => instance.isHead).map(instance => instance.repoId);
         const localRepoIds = localInstances.map(instance => instance.repoId);
@@ -295,8 +298,8 @@ export const BranchSidebar = forwardRef<HTMLDivElement, Props>(function BranchSi
             canDelete={!contextMenu.merged.isHead}
             onClose={() => setContextMenu(null)}
             onCheckout={() => { onCheckout(contextMenu.merged.repoIds, inst.name); setContextMenu(null); }}
-            onMerge={() => { onMerge(inst.repoId, inst.name); setContextMenu(null); }}
-            onRebase={() => { onRebase(inst.repoId, inst.name); setContextMenu(null); }}
+            onMerge={() => { onMerge(opInst.repoId, opInst.name); setContextMenu(null); }}
+            onRebase={() => { onRebase(opInst.repoId, opInst.name); setContextMenu(null); }}
             onDelete={() => { onDelete(contextMenu.merged.repoIds, inst.name); setContextMenu(null); }}
             onPull={currentLocalRepoIds.length > 0 ? () => { onPull(currentLocalRepoIds, contextMenu.merged.baseName); setContextMenu(null); } : undefined}
             onPush={localRepoIds.length > 0 ? () => { onPush(localRepoIds, contextMenu.merged.baseName); setContextMenu(null); } : undefined}


### PR DESCRIPTION
### What this fixes

- Merging a branch did nothing while still showing a success message (RioNoir/GitCharm#31).
- Picking a remote branch like `origin/main` in the status bar menu merged the local `main` instead. That local branch is often stale and already merged, so git said "Already up to date" and stopped there.
- GitCharm reported "Merged ..." even when git changed nothing, so there was no way to tell a real merge from a no-op.
- In the Log panel, the branch right-click menu ran the merge in the repository where that branch is already checked out — the one place where merging it can never do anything.
- A failed merge or rebase from the Log panel was written only to the webview console, so the user saw no error at all.

### Changes

- Remote entries in the status bar branch menu now pass the full ref (`origin/main`) to merge, rebase and compare. Checkout, pull and rename keep using the local branch name.
- `GitService.merge` compares HEAD before and after the merge and returns whether it moved.
- All merge callers use that result: an up-to-date merge now says "already up to date — nothing to merge" instead of reporting success.
- The multi-repo merge notification counts only the repositories that actually merged, not every repository it visited.
- The Log panel branch menu picks a repository where the branch is not the current one.
- The Log panel refreshes the graph after a merge or rebase succeeds, and shows failures as notifications.

Fixes #31