### PR TITLE
Show only refs that point at the selected commit

### DIFF
--- a/src/host/git/GitService.ts
+++ b/src/host/git/GitService.ts
@@ -1596,24 +1596,20 @@ export class GitService {
     await this.git.raw(['merge', name]);
   }
 
-  async getBranchesContaining(hash: string): Promise<{ local: string[]; remote: string[]; tags: string[] }> {
-    const [localOut, remoteOut, tagOut] = await Promise.all([
-      this.git.raw(['branch', '--contains', hash, '--format=%(refname:short)']).catch(() => ''),
-      this.git.raw(['branch', '-r', '--contains', hash, '--format=%(refname:short)']).catch(() => ''),
-      // --points-at: only tags directly on this commit, not ancestors.
-      this.git.raw(['tag', '--points-at', hash]).catch(() => ''),
-    ]);
-    const parse = (out: string) => out.split('\n').map(b => b.trim()).filter(Boolean);
-    // Local branches must not contain a slash — anything with '/' is a remote ref
-    // that leaked into the local output on some git configurations.
-    // Exclude remote-leaked refs (contain '/') and the detached HEAD pseudo-entry "(HEAD detached at ...)".
-    const local = parse(localOut).filter(b => !b.includes('/') && !b.startsWith('('));
-    // Remote names come as "origin/foo" or "remotes/origin/foo" — normalise both.
-    // origin/HEAD is a symbolic alias, not a real branch — skip it here.
-    const remote = parse(remoteOut)
-      .map(b => b.replace(/^remotes\//, ''))
-      .filter(b => !b.endsWith('/HEAD') && b.includes('/'));
-    const tags = parse(tagOut);
+  // Refs that point AT this commit — never branches that merely contain it.
+  // --points-at peels annotated tags, so one call covers heads, remotes and tags.
+  async getRefsAt(hash: string): Promise<{ local: string[]; remote: string[]; tags: string[] }> {
+    const out = await this.git.raw(['for-each-ref', '--points-at', hash, '--format=%(refname)']).catch(() => '');
+    const local: string[] = [], remote: string[] = [], tags: string[] = [];
+    for (const ref of out.split('\n').map(r => r.trim()).filter(Boolean)) {
+      if (ref.startsWith('refs/heads/')) local.push(ref.slice('refs/heads/'.length));
+      else if (ref.startsWith('refs/tags/')) tags.push(ref.slice('refs/tags/'.length));
+      else if (ref.startsWith('refs/remotes/')) {
+        const name = ref.slice('refs/remotes/'.length);
+        // <remote>/HEAD is a symbolic alias, not a branch.
+        if (name.includes('/') && !name.endsWith('/HEAD')) remote.push(name);
+      }
+    }
     return { local, remote, tags };
   }
 

--- a/src/host/panels/CommitDetailPanel.ts
+++ b/src/host/panels/CommitDetailPanel.ts
@@ -34,7 +34,7 @@ export async function openCommitDetailPanel(
     commitInfo ??= { hash, shortHash: hash.slice(0, 7), message: '', authorName: '', authorEmail: '', authorDate: '', committerDate: '', parents: [] };
     [files, branches] = await Promise.all([
       repo.getCommitFiles(hash, commitInfo.parents),
-      repo.getBranchesContaining(hash).catch(() => ({ local: [], remote: [], tags: [] })),
+      repo.getRefsAt(hash).catch(() => ({ local: [], remote: [], tags: [] })),
     ]);
   } catch (e: unknown) {
     showGitError('commitDetail:load', e);

--- a/src/host/panels/GitLogPanelProvider.ts
+++ b/src/host/panels/GitLogPanelProvider.ts
@@ -1409,15 +1409,6 @@ export class GitLogPanelProvider implements vscode.WebviewViewProvider, vscode.D
         break;
       }
 
-      case 'LOG_REQUEST_COMMIT_BRANCHES': {
-        const repo = this.manager.getRepo(msg.repoId);
-        const branches = repo
-          ? await repo.getBranchesContaining(msg.hash).catch(() => ({ local: [], remote: [], tags: [] }))
-          : { local: [], remote: [], tags: [] };
-        this.post({ type: 'LOG_COMMIT_BRANCHES_RESULT', requestId: msg.requestId, branches });
-        break;
-      }
-
       case 'LOG_REQUEST_TAGS': {
         const repo = this.manager.getRepo(msg.repoId);
         if (!repo) return;

--- a/src/host/types/messages.ts
+++ b/src/host/types/messages.ts
@@ -222,7 +222,6 @@ export type HostToLogMsg =
   | { type: 'LOG_REFRESH' }
   | { type: 'LOG_MERGE_COMMITS_RESULT'; requestId: string; commits: MergeParentCommit[]; error?: string }
   | { type: 'LOG_FILE_OP_RESULT'; requestId: string; ok: boolean; error?: string }
-  | { type: 'LOG_COMMIT_BRANCHES_RESULT'; requestId: string; branches: { local: string[]; remote: string[]; tags: string[] } }
   | { type: 'LOG_SCROLL_TO_COMMIT'; hash: string; repoId: string }
   | { type: 'LOG_COMMIT_BODY_RESULT'; requestId: string; hasBody: boolean }
   | { type: 'LOG_FILTER_BY_REPO'; repoId: string | null; branch?: string | null }
@@ -282,7 +281,6 @@ export type LogToHostMsg =
   | { type: 'LOG_RESET_TO_PICK'; repoId: string; hash: string }
   | { type: 'LOG_PUSH_PICK'; repoId: string }
   | { type: 'LOG_PUSH_TAG_PICK'; repoId: string; tagName: string }
-  | { type: 'LOG_REQUEST_COMMIT_BRANCHES'; requestId: string; repoId: string; hash: string }
   | { type: 'LOG_OPEN_COMMIT_BODY'; requestId: string; repoId: string; hash: string }
   | { type: 'LOG_SHOW_BRANCH_OPTIONS'; repoId: string; branchName: string }
   | { type: 'LOG_CHECKOUT_COMMIT'; requestId: string; repoId: string; hash: string; branchName?: string }

--- a/src/webview/gitLog/components/CommitDetail.tsx
+++ b/src/webview/gitLog/components/CommitDetail.tsx
@@ -354,8 +354,6 @@ export function CommitDetail({ commit, range, files, selectedFile, loadingFiles,
   const [loadingMergeFiles, setLoadingMergeFiles] = useState(false);
   const pendingRef = useRef<Map<string, (msg: HostToLogMsg) => void>>(new Map());
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; file: FileEntry } | null>(null);
-  const [containingBranches, setContainingBranches] = useState<{ local: string[]; remote: string[]; tags: string[] }>({ local: [], remote: [], tags: [] });
-  const [loadingBranches, setLoadingBranches] = useState(false);
   const [refsExpanded, setRefsExpanded] = useState(false);
 
   const repoName = useMemo(() => {
@@ -380,24 +378,7 @@ export function CommitDetail({ commit, range, files, selectedFile, loadingFiles,
     return () => window.removeEventListener('message', handler);
   }, []);
 
-  useEffect(() => {
-    if (range || !commit || commit.isStash) { setContainingBranches({ local: [], remote: [], tags: [] }); setLoadingBranches(false); return; }
-    setRefsExpanded(false);
-    setLoadingBranches(true);
-    const reqId = generateId();
-    pendingRef.current.set(reqId, (msg) => {
-      if (msg.type === 'LOG_COMMIT_BRANCHES_RESULT') {
-        setContainingBranches(msg.branches);
-        setLoadingBranches(false);
-      }
-    });
-    getVsCodeApi().postMessage({
-      type: 'LOG_REQUEST_COMMIT_BRANCHES',
-      requestId: reqId,
-      repoId: commit.repoId,
-      hash: commit.hash,
-    } satisfies LogToHostMsg);
-  }, [commit?.hash, range]);
+  useEffect(() => { setRefsExpanded(false); }, [commit?.hash, range]);
 
   useEffect(() => {
     setSelectedMergeHash(null);
@@ -664,107 +645,35 @@ export function CommitDetail({ commit, range, files, selectedFile, loadingFiles,
         )}
         {(() => {
           const LIMIT = 5;
+          // Only refs that point AT this commit — never branches that merely contain it.
           const refGroups = groupRefs(commit.refs);
+          const other = (g: RefGroup) => !g.isHead && !g.isTag;
+          const pick = (f: (g: RefGroup) => boolean) => refGroups.filter(f);
 
-          // Build a flat list of all badges to display, deduplicating by label.
-          // Order:
-          //   1. HEAD branch (isHead, already first from groupRefs)
-          //   2. Tags directly on this commit (from refs)
-          //   3. Primary local branches (main/master/…) — from refs first, then containing
-          //   4. Other local branches — from refs first, then containing
-          //   5. Primary remote branches — from refs first, then containing
-          //   6. Other remote branches — from refs first, then containing
-          //   7. Tags from --contains (not directly on commit)
-          // Collect remote names from refGroups (e.g. "origin") to filter out bare
-          // remote-pointer refs that git sometimes emits as short-form locals (e.g. "origin").
-          const remoteNames = new Set(refGroups.filter(g => g.isRemote).map(g => g.remoteName).filter(Boolean));
-          // Also collect remote names from containingBranches (e.g. "origin" from "origin/main").
-          containingBranches.remote.forEach(b => { const r = b.includes('/') ? b.slice(0, b.indexOf('/')) : ''; if (r) remoteNames.add(r); });
-
-          const refLabels = new Set(refGroups.filter(g => !remoteNames.has(g.label)).map(g => g.label));
-          type Badge =
-            | { kind: 'ref'; group: RefGroup }
-            | { kind: 'local'; name: string }
-            | { kind: 'remote'; name: string; remoteName: string }
-            | { kind: 'tag'; name: string };
-
-          const headBadges    = refGroups.filter(g => g.isHead).map(g => ({ kind: 'ref' as const, group: g }));
-          const refTagBadges  = refGroups.filter(g => g.isTag).map(g => ({ kind: 'ref' as const, group: g }));
-          // Exclude bare remote-pointer refs parsed as locals (e.g. "origin" when "origin/main" is also present).
-          const refLocalPrim  = refGroups.filter(g => !g.isHead && !g.isTag && g.isLocal && !remoteNames.has(g.label) && isPrimaryBranch(g.label)).map(g => ({ kind: 'ref' as const, group: g }));
-          const refLocalOther = refGroups.filter(g => !g.isHead && !g.isTag && g.isLocal && !remoteNames.has(g.label) && !isPrimaryBranch(g.label)).map(g => ({ kind: 'ref' as const, group: g }));
-          const refRemPrim    = refGroups.filter(g => !g.isHead && !g.isTag && g.isRemote && isPrimaryBranch(g.label)).map(g => ({ kind: 'ref' as const, group: g }));
-          const refRemOther   = refGroups.filter(g => !g.isHead && !g.isTag && g.isRemote && !isPrimaryBranch(g.label)).map(g => ({ kind: 'ref' as const, group: g }));
-
-          // Strip remote prefix (upstream/foo → foo), used for dedup.
-          const stripRemote  = (b: string) => b.includes('/') ? b.slice(b.indexOf('/') + 1) : b;
-          const getRemote    = (b: string) => b.includes('/') ? b.slice(0, b.indexOf('/')) : '';
-          const isHEADRef    = (b: string) => stripRemote(b).toUpperCase() === 'HEAD';
-
-          // Local branches from --contains must never contain '/' — anything with
-          // a slash is a remote ref that leaked through (some git versions do this).
-          // Also deduplicate against refLabels which are already normalized.
-          const localOnly = containingBranches.local.filter(b => !b.includes('/'));
-          const extraLocalPrim  = localOnly.filter(b => !refLabels.has(b) && isPrimaryBranch(b)).map(b => ({ kind: 'local' as const, name: b }));
-          const extraLocalOther = localOnly.filter(b => !refLabels.has(b) && !isPrimaryBranch(b)).map(b => ({ kind: 'local' as const, name: b }));
-
-          // Remote dedup: strip prefix before comparing with refLabels. Preserve remote name for display.
-          const extraRemPrim    = containingBranches.remote.filter(b => !isHEADRef(b) && !refLabels.has(stripRemote(b)) && isPrimaryBranch(stripRemote(b))).map(b => ({ kind: 'remote' as const, name: stripRemote(b), remoteName: getRemote(b) }));
-          const extraRemOther   = containingBranches.remote.filter(b => !isHEADRef(b) && !refLabels.has(stripRemote(b)) && !isPrimaryBranch(stripRemote(b))).map(b => ({ kind: 'remote' as const, name: stripRemote(b), remoteName: getRemote(b) }));
-          const extraTags       = containingBranches.tags.filter(t => !refLabels.has(t)).map(t => ({ kind: 'tag' as const, name: t }));
-
-          const allBadges: Badge[] = [
-            ...headBadges,
-            ...refTagBadges,
-            ...refLocalPrim,  ...extraLocalPrim,
-            ...refLocalOther, ...extraLocalOther,
-            ...refRemPrim,    ...extraRemPrim,
-            ...refRemOther,   ...extraRemOther,
-            ...extraTags,
+          // Order: HEAD, tags, primary locals, other locals, primary remotes, other remotes.
+          const allBadges: RefGroup[] = [
+            ...pick(g => g.isHead),
+            ...pick(g => g.isTag),
+            ...pick(g => other(g) && g.isLocal && isPrimaryBranch(g.label)),
+            ...pick(g => other(g) && g.isLocal && !isPrimaryBranch(g.label)),
+            ...pick(g => other(g) && !g.isLocal && isPrimaryBranch(g.label)),
+            ...pick(g => other(g) && !g.isLocal && !isPrimaryBranch(g.label)),
           ];
-
-          const isEmpty = allBadges.length === 0;
-          if (isEmpty && !loadingBranches) return null;
+          if (allBadges.length === 0) return null;
 
           const visible = refsExpanded ? allBadges : allBadges.slice(0, LIMIT);
           const hiddenCount = allBadges.length - LIMIT;
 
-          function renderBadge(badge: Badge, key: string) {
-            if (badge.kind === 'ref') {
-              const g = badge.group;
-              const isSpecialHead = g.isRemoteHead || (g.isHead && g.isDetached);
-              const rid = commit!.repoId;
-              const remoteRefKey = g.remoteName ? `${rid}:${g.remoteName}/${g.label}` : null;
-              const resolvedRefColor = (remoteRefKey ? refColors?.get(remoteRefKey) : undefined) ?? refColors?.get(`${rid}:${g.label}`);
-              const color = g.isTag ? tagColor() : isSpecialHead ? headColor() : (resolvedRefColor ?? branchColor(g.label, false));
-              const label = g.isRemoteHead ? `${g.remoteName}/HEAD` : g.isRemote ? remoteLabel(g) : g.label;
-              return (
-                <span key={key} style={styles.refBadge(color, (g.isHead || g.isDetached) && !g.isRemoteHead)} title={badgeTitle(g)}>
-                  <RefBadgeIcon group={g} />
-                  {label}
-                </span>
-              );
-            }
-            if (badge.kind === 'tag') {
-              const color = tagColor();
-              return (
-                <span key={key} style={styles.refBadge(color)} title={`Tag: ${badge.name}`}>
-                  <Codicon name="tag" style={{ fontSize: '11px', flexShrink: 0, lineHeight: 1 }} />
-                  {badge.name}
-                </span>
-              );
-            }
-            const isRemote = badge.kind === 'remote';
-            const isRemoteHead = isRemote && badge.name.toUpperCase() === 'HEAD';
-            const rName = isRemote ? (badge as { remoteName: string }).remoteName : '';
-            const rid2 = commit!.repoId;
-            const remoteBadgeKey = rName ? `${rid2}:${rName}/${badge.name}` : null;
-            const resolvedBadgeColor = (remoteBadgeKey ? refColors?.get(remoteBadgeKey) : undefined) ?? refColors?.get(`${rid2}:${badge.name}`);
-            const color = isRemoteHead ? headColor() : (resolvedBadgeColor ?? branchColor(badge.name, false));
-            const label = isRemote ? (isRemoteHead ? 'HEAD' : `${rName || 'remote'}/${badge.name}`) : badge.name;
+          function renderBadge(g: RefGroup) {
+            const isSpecialHead = g.isRemoteHead || (g.isHead && g.isDetached);
+            const rid = commit!.repoId;
+            const remoteRefKey = g.remoteName ? `${rid}:${g.remoteName}/${g.label}` : null;
+            const resolvedRefColor = (remoteRefKey ? refColors?.get(remoteRefKey) : undefined) ?? refColors?.get(`${rid}:${g.label}`);
+            const color = g.isTag ? tagColor() : isSpecialHead ? headColor() : (resolvedRefColor ?? branchColor(g.label, false));
+            const label = g.isRemoteHead ? `${g.remoteName}/HEAD` : g.isRemote ? remoteLabel(g) : g.label;
             return (
-              <span key={key} style={styles.refBadge(color, isRemoteHead)} title={isRemoteHead ? `Remote HEAD (${rName}/HEAD)` : `${isRemote ? 'Remote branch' : 'Branch'}: ${label}`}>
-                <Codicon name={isRemoteHead ? 'milestone' : isRemote ? 'cloud' : 'git-branch'} style={{ fontSize: '11px', flexShrink: 0, lineHeight: 1 }} />
+              <span key={g.key} style={styles.refBadge(color, (g.isHead || g.isDetached) && !g.isRemoteHead)} title={badgeTitle(g)}>
+                <RefBadgeIcon group={g} />
                 {label}
               </span>
             );
@@ -779,7 +688,7 @@ export function CommitDetail({ commit, range, files, selectedFile, loadingFiles,
                   HEAD
                 </span>
               )}
-              {visible.map((badge, i) => renderBadge(badge, String(i)))}
+              {visible.map(renderBadge)}
               {!refsExpanded && hiddenCount > 0 && (
                 <span
                   style={styles.refsShowMore}
@@ -788,9 +697,6 @@ export function CommitDetail({ commit, range, files, selectedFile, loadingFiles,
                 >
                   +{hiddenCount} more
                 </span>
-              )}
-              {loadingBranches && allBadges.length === 0 && (
-                <span style={styles.refsLoadingLabel}>…</span>
               )}
               {refsExpanded && allBadges.length > LIMIT && (
                 <span
@@ -1115,25 +1021,12 @@ const styles = {
     overflowY: 'auto' as const,
     paddingRight: '2px',
   },
-  refsMoreLabel: {
-    fontSize: '10px',
-    opacity: 0.5,
-    color: 'var(--vscode-foreground)',
-    cursor: 'default',
-    alignSelf: 'center',
-  } as React.CSSProperties,
   refsShowMore: {
     fontSize: '10px',
     color: 'var(--vscode-textLink-foreground)',
     cursor: 'pointer',
     alignSelf: 'center',
     flexShrink: 0,
-  } as React.CSSProperties,
-  refsLoadingLabel: {
-    fontSize: '10px',
-    opacity: 0.4,
-    color: 'var(--vscode-foreground)',
-    alignSelf: 'center',
   } as React.CSSProperties,
   refBadge: (color: string, isHead = false): React.CSSProperties => ({
     fontSize: '10px',

--- a/src/webview/gitLog/components/CommitList.tsx
+++ b/src/webview/gitLog/components/CommitList.tsx
@@ -530,7 +530,7 @@ export function CommitList({ layout, selectedHash, repoColors, repos, activeRepo
                 type DisplayItem = RefGroup | '__HEAD__';
                 const displayItems: DisplayItem[] = [
                   ...(headBranchGroup ? [HEAD_SENTINEL] : []),
-                  ...allGroups.filter(g => !(headAndRemoteHead && g.isRemoteHead)),
+                  ...allGroups.filter(g => !(headAndRemoteHead && g === remoteHeadGroup)),
                 ];
 
                 const refsSpace = containerWidth - labelColWidth - 340;
@@ -809,7 +809,7 @@ function CommitPopover({ commit, rowTop, listRect, mouseX, onClose, popoverHover
         const popoverHeadGroup = refGroups.find(g => g.isHead && !g.isDetached);
         const popoverRemoteHeadGroup = refGroups.find(g => g.isRemoteHead);
         const headAndRemoteHead = popoverHeadGroup && popoverRemoteHeadGroup;
-        const displayGroups = headAndRemoteHead ? refGroups.filter(g => !g.isRemoteHead) : refGroups;
+        const displayGroups = headAndRemoteHead ? refGroups.filter(g => g !== popoverRemoteHeadGroup) : refGroups;
         const hc = headColor();
         return (
           <div style={popoverStyles.refs}>
@@ -1524,13 +1524,20 @@ const ctxStyles = {
   } as React.CSSProperties,
 };
 
+// A branch can live on several remotes (origin/main + upstream/main) — keep them all.
+function joinRemoteNames(a: string, b: string): string {
+  if (!a) return b;
+  if (!b || a.split(' & ').includes(b)) return a;
+  return `${a} & ${b}`;
+}
+
 function mergeLocalRemote(groups: RefGroup[]): RefGroup[] {
   const merged: RefGroup[] = [];
   const seen = new Map<string, RefGroup>();
   for (const g of groups) {
     if (!g.isTag && !g.isRemoteHead && !g.isDetached && seen.has(g.label)) {
       const existing = seen.get(g.label)!;
-      const combined: RefGroup = { ...existing, isLocal: existing.isLocal || g.isLocal, isRemote: existing.isRemote || g.isRemote, remoteName: existing.remoteName || g.remoteName };
+      const combined: RefGroup = { ...existing, isLocal: existing.isLocal || g.isLocal, isRemote: existing.isRemote || g.isRemote, remoteName: joinRemoteNames(existing.remoteName, g.remoteName) };
       seen.set(g.label, combined);
       const idx = merged.findIndex(x => x.key === existing.key);
       if (idx >= 0) merged[idx] = combined;

--- a/src/webview/gitLog/utils/refs.ts
+++ b/src/webview/gitLog/utils/refs.ts
@@ -67,12 +67,12 @@ function normalizeRef(raw: string): { kind: 'head-pointer'; branch: string }
 }
 
 export function groupRefs(refs: string[]): RefGroup[] {
-  const remotes = new Map<string, string>(); // branchName → remoteName
+  const remotes: Array<{ remoteName: string; name: string }> = [];
   const locals = new Set<string>();
   const tags: string[] = [];
   let headBranch: string | null = null;
   let isDetached = false;
-  let remoteHeadRemoteName: string | null = null;
+  const remoteHeads: string[] = [];   // remotes whose <remote>/HEAD points here
 
   for (const ref of refs) {
     const parsed = normalizeRef(ref);
@@ -88,14 +88,16 @@ export function groupRefs(refs: string[]): RefGroup[] {
       case 'local':
         locals.add(parsed.name);
         break;
-      case 'remote':
-        if (parsed.name.toUpperCase() === 'HEAD') {
-          remoteHeadRemoteName = parsed.remoteName;
-        } else {
-          // Last remote wins if multiple remotes track the same branch name — shouldn't happen in practice.
-          remotes.set(parsed.name, parsed.remoteName);
+      case 'remote': {
+        const { remoteName, name } = parsed;
+        if (name.toUpperCase() === 'HEAD') {
+          if (!remoteHeads.includes(remoteName)) remoteHeads.push(remoteName);
+        } else if (!remotes.some(r => r.remoteName === remoteName && r.name === name)) {
+          // Keyed by remote+name: origin/main and upstream/main are distinct refs.
+          remotes.push({ remoteName, name });
         }
         break;
+      }
       case 'tag':
         tags.push(parsed.name);
         break;
@@ -125,8 +127,8 @@ export function groupRefs(refs: string[]): RefGroup[] {
     });
   }
 
-  // <remote>/HEAD symbolic pointer
-  if (remoteHeadRemoteName !== null) {
+  // <remote>/HEAD symbolic pointers (one per remote)
+  for (const remoteHeadRemoteName of remoteHeads) {
     groups.push({
       key: `${remoteHeadRemoteName}/HEAD`,
       label: 'HEAD',
@@ -141,8 +143,6 @@ export function groupRefs(refs: string[]): RefGroup[] {
   }
 
   for (const local of locals) {
-    const remoteEntry = remotes.get(local);
-    const synced = remoteEntry !== undefined;
     groups.push({
       key: local,
       label: local,
@@ -154,25 +154,11 @@ export function groupRefs(refs: string[]): RefGroup[] {
       isDetached: false,
       isRemoteHead: false,
     });
-    if (synced) {
-      groups.push({
-        key: `remote:${local}`,
-        label: local,
-        remoteName: remoteEntry,
-        isHead: false,
-        isLocal: false,
-        isRemote: true,
-        isTag: false,
-        isDetached: false,
-        isRemoteHead: false,
-      });
-      remotes.delete(local);
-    }
   }
 
-  for (const [name, remoteName] of remotes) {
+  for (const { remoteName, name } of remotes) {
     groups.push({
-      key: `remote:${name}`,
+      key: `remote:${remoteName}/${name}`,
       label: name,
       remoteName,
       isHead: false,
@@ -205,7 +191,7 @@ export function groupRefs(refs: string[]): RefGroup[] {
     if (a.isTag !== b.isTag) return a.isTag ? 1 : -1;
     if (a.label !== b.label) return a.label.localeCompare(b.label);
     if (a.isLocal !== b.isLocal) return a.isLocal ? -1 : 1;
-    return 0;
+    return a.remoteName.localeCompare(b.remoteName);
   });
 
   return groups;


### PR DESCRIPTION
The details panel merged `git branch --contains` output into the ref badges, so every branch descended from a commit looked like it pointed at it. Drop that lookup and render only the refs on the commit itself.

Also fix ref grouping losing refs when several remotes share a branch name: remotes were keyed by branch name alone, so upstream/main overwrote origin/main and one <remote>/HEAD overwrote the other.